### PR TITLE
feat: 실제 배차 요청 API 추가

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ConfirmDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ConfirmDispatchService.kt
@@ -1,0 +1,88 @@
+package com.baro.dispatch.application.service
+
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.model.GeoPoint
+import com.baro.dispatch.domain.repository.DispatchRepository
+import com.baro.dispatch.domain.repository.DispatchRequestRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.OffsetDateTime
+
+@Service
+class ConfirmDispatchService(
+    private val dispatchRequestRepository: DispatchRequestRepository,
+    private val dispatchRepository: DispatchRepository,
+    private val clock: Clock,
+) {
+    @Transactional
+    fun confirm(command: ConfirmDispatchCommand): ConfirmDispatchResult {
+        val preDispatchRequest = dispatchRequestRepository.findById(command.requestId)
+            ?: throw IllegalArgumentException("PRE배차 요청을 찾을 수 없습니다.")
+
+        require(preDispatchRequest.userId == command.userId) { "PRE배차 요청 사용자와 배차 요청 사용자가 일치하지 않습니다." }
+
+        // TODO: 차량/승차장 조회 및 배정 로직을 control-service 연동 또는 별도 포트로 구현한다.
+        val temporaryCarId = TEMPORARY_CAR_ID
+        val temporaryStandId = TEMPORARY_STAND_ID
+        val temporaryPickupRoutePath = emptyList<GeoPoint>()
+        val temporaryEstimatedPickupTime = 0
+
+        val dispatch = Dispatch.requested(
+            requestId = command.requestId,
+            userId = command.userId,
+            carId = temporaryCarId,
+            standId = temporaryStandId,
+            createdAt = OffsetDateTime.now(clock),
+            estimatedPickupTime = temporaryEstimatedPickupTime,
+            estimatedRideTime = preDispatchRequest.estimatedTime,
+            pickupRoutePath = temporaryPickupRoutePath,
+            dropoffRoutePath = preDispatchRequest.routePath,
+            fare = preDispatchRequest.fare,
+        )
+        val dispatchId = dispatchRepository.save(dispatch)
+
+        return ConfirmDispatchResult(
+            dispatchId = dispatchId,
+            requestId = command.requestId,
+            userId = command.userId,
+            carId = temporaryCarId,
+            standId = temporaryStandId,
+            estimatedPickupTime = temporaryEstimatedPickupTime,
+            estimatedRideTime = preDispatchRequest.estimatedTime,
+            pickupRoutePath = temporaryPickupRoutePath,
+            dropoffRoutePath = preDispatchRequest.routePath,
+            fare = preDispatchRequest.fare,
+            status = dispatch.status.name,
+        )
+    }
+
+    private companion object {
+        const val TEMPORARY_CAR_ID = 0L
+        const val TEMPORARY_STAND_ID = 0L
+    }
+}
+
+data class ConfirmDispatchCommand(
+    val requestId: Long,
+    val userId: Long,
+) {
+    init {
+        require(requestId > 0) { "PRE배차 요청 ID는 양수여야 합니다." }
+        require(userId > 0) { "사용자 ID는 양수여야 합니다." }
+    }
+}
+
+data class ConfirmDispatchResult(
+    val dispatchId: Long,
+    val requestId: Long,
+    val userId: Long,
+    val carId: Long,
+    val standId: Long,
+    val estimatedPickupTime: Int,
+    val estimatedRideTime: Int,
+    val pickupRoutePath: List<GeoPoint>,
+    val dropoffRoutePath: List<GeoPoint>,
+    val fare: Int,
+    val status: String,
+)

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ConfirmDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ConfirmDispatchService.kt
@@ -1,12 +1,14 @@
 package com.baro.dispatch.application.service
 
 import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.model.DispatchRequestStatus
 import com.baro.dispatch.domain.model.GeoPoint
 import com.baro.dispatch.domain.repository.DispatchRepository
 import com.baro.dispatch.domain.repository.DispatchRequestRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
+import java.time.Duration
 import java.time.OffsetDateTime
 
 @Service
@@ -17,10 +19,13 @@ class ConfirmDispatchService(
 ) {
     @Transactional
     fun confirm(command: ConfirmDispatchCommand): ConfirmDispatchResult {
+        val now = OffsetDateTime.now(clock)
         val preDispatchRequest = dispatchRequestRepository.findById(command.requestId)
             ?: throw IllegalArgumentException("PRE배차 요청을 찾을 수 없습니다.")
 
         require(preDispatchRequest.userId == command.userId) { "PRE배차 요청 사용자와 배차 요청 사용자가 일치하지 않습니다." }
+        require(preDispatchRequest.status == DispatchRequestStatus.PENDING) { "이미 처리된 PRE배차 요청입니다." }
+        require(!preDispatchRequest.isExpired(now)) { "만료된 PRE배차 요청입니다." }
 
         // TODO: 차량/승차장 조회 및 배정 로직을 control-service 연동 또는 별도 포트로 구현한다.
         val temporaryCarId = TEMPORARY_CAR_ID
@@ -33,7 +38,7 @@ class ConfirmDispatchService(
             userId = command.userId,
             carId = temporaryCarId,
             standId = temporaryStandId,
-            createdAt = OffsetDateTime.now(clock),
+            createdAt = now,
             estimatedPickupTime = temporaryEstimatedPickupTime,
             estimatedRideTime = preDispatchRequest.estimatedTime,
             pickupRoutePath = temporaryPickupRoutePath,
@@ -41,6 +46,7 @@ class ConfirmDispatchService(
             fare = preDispatchRequest.fare,
         )
         val dispatchId = dispatchRepository.save(dispatch)
+        dispatchRequestRepository.save(preDispatchRequest.markMatched(now))
 
         return ConfirmDispatchResult(
             dispatchId = dispatchId,
@@ -60,6 +66,10 @@ class ConfirmDispatchService(
     private companion object {
         const val TEMPORARY_CAR_ID = 0L
         const val TEMPORARY_STAND_ID = 0L
+        val PRE_DISPATCH_EXPIRATION: Duration = Duration.ofMinutes(10)
+
+        fun com.baro.dispatch.domain.model.DispatchRequest.isExpired(now: OffsetDateTime): Boolean =
+            requestedAt.plus(PRE_DISPATCH_EXPIRATION).isBefore(now)
     }
 }
 

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/PreDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/PreDispatchService.kt
@@ -5,6 +5,7 @@ import com.baro.dispatch.domain.model.DispatchRequest
 import com.baro.dispatch.domain.model.GeoPoint
 import com.baro.dispatch.domain.repository.DispatchRequestRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.OffsetDateTime
 import kotlin.math.ceil
@@ -16,6 +17,7 @@ class PreDispatchService(
     private val dispatchRequestRepository: DispatchRequestRepository,
     private val clock: Clock,
 ) {
+    @Transactional
     fun estimate(command: PreDispatchCommand): PreDispatchResult {
         val routeEstimate = directionsPort.findRoute(command.origin, command.destination)
         val estimatedTime = ceil(routeEstimate.durationSeconds / SECONDS_PER_MINUTE).toInt()

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/PreDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/PreDispatchService.kt
@@ -5,7 +5,6 @@ import com.baro.dispatch.domain.model.DispatchRequest
 import com.baro.dispatch.domain.model.GeoPoint
 import com.baro.dispatch.domain.repository.DispatchRequestRepository
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.OffsetDateTime
 import kotlin.math.ceil
@@ -17,7 +16,6 @@ class PreDispatchService(
     private val dispatchRequestRepository: DispatchRequestRepository,
     private val clock: Clock,
 ) {
-    @Transactional
     fun estimate(command: PreDispatchCommand): PreDispatchResult {
         val routeEstimate = directionsPort.findRoute(command.origin, command.destination)
         val estimatedTime = ceil(routeEstimate.durationSeconds / SECONDS_PER_MINUTE).toInt()

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/model/Dispatch.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/model/Dispatch.kt
@@ -3,6 +3,7 @@ package com.baro.dispatch.domain.model
 import java.time.OffsetDateTime
 
 data class Dispatch(
+    val id: Long? = null,
     val requestId: Long,
     val userId: Long,
     val carId: Long,
@@ -39,6 +40,7 @@ data class Dispatch(
             fare: Int,
         ): Dispatch =
             Dispatch(
+                id = null,
                 requestId = requestId,
                 userId = userId,
                 carId = carId,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/model/Dispatch.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/model/Dispatch.kt
@@ -1,0 +1,62 @@
+package com.baro.dispatch.domain.model
+
+import java.time.OffsetDateTime
+
+data class Dispatch(
+    val requestId: Long,
+    val userId: Long,
+    val carId: Long,
+    val standId: Long,
+    val createdAt: OffsetDateTime,
+    val estimatedPickupTime: Int,
+    val estimatedRideTime: Int,
+    val pickupRoutePath: List<GeoPoint>,
+    val dropoffRoutePath: List<GeoPoint>,
+    val fare: Int,
+    val status: DispatchStatus,
+) {
+    init {
+        require(requestId > 0) { "PRE배차 요청 ID는 양수여야 합니다." }
+        require(userId > 0) { "사용자 ID는 양수여야 합니다." }
+        require(carId >= 0) { "차량 ID는 0 이상이어야 합니다." }
+        require(standId >= 0) { "승차장 ID는 0 이상이어야 합니다." }
+        require(estimatedPickupTime >= 0) { "예상 픽업 시간은 0 이상이어야 합니다." }
+        require(estimatedRideTime >= 0) { "예상 운행 시간은 0 이상이어야 합니다." }
+        require(fare >= 0) { "요금은 0 이상이어야 합니다." }
+    }
+
+    companion object {
+        fun requested(
+            requestId: Long,
+            userId: Long,
+            carId: Long,
+            standId: Long,
+            createdAt: OffsetDateTime,
+            estimatedPickupTime: Int,
+            estimatedRideTime: Int,
+            pickupRoutePath: List<GeoPoint>,
+            dropoffRoutePath: List<GeoPoint>,
+            fare: Int,
+        ): Dispatch =
+            Dispatch(
+                requestId = requestId,
+                userId = userId,
+                carId = carId,
+                standId = standId,
+                createdAt = createdAt,
+                estimatedPickupTime = estimatedPickupTime,
+                estimatedRideTime = estimatedRideTime,
+                pickupRoutePath = pickupRoutePath,
+                dropoffRoutePath = dropoffRoutePath,
+                fare = fare,
+                status = DispatchStatus.REQUESTED,
+            )
+    }
+}
+
+enum class DispatchStatus {
+    REQUESTED,
+    ASSIGNED,
+    CANCELLED,
+    COMPLETED,
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/model/DispatchRequest.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/model/DispatchRequest.kt
@@ -3,6 +3,7 @@ package com.baro.dispatch.domain.model
 import java.time.OffsetDateTime
 
 data class DispatchRequest(
+    val id: Long? = null,
     val userId: Long,
     val origin: GeoPoint,
     val destination: GeoPoint,
@@ -21,6 +22,12 @@ data class DispatchRequest(
         require(distanceKm >= 0) { "예상 거리는 0 이상이어야 합니다." }
     }
 
+    fun markMatched(now: OffsetDateTime): DispatchRequest {
+        require(status == DispatchRequestStatus.PENDING) { "이미 처리된 PRE배차 요청입니다." }
+
+        return copy(status = DispatchRequestStatus.MATCHED, updatedAt = now)
+    }
+
     companion object {
         fun pending(
             userId: Long,
@@ -33,6 +40,7 @@ data class DispatchRequest(
             now: OffsetDateTime,
         ): DispatchRequest =
             DispatchRequest(
+                id = null,
                 userId = userId,
                 origin = origin,
                 destination = destination,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/repository/DispatchRepository.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/repository/DispatchRepository.kt
@@ -1,0 +1,7 @@
+package com.baro.dispatch.domain.repository
+
+import com.baro.dispatch.domain.model.Dispatch
+
+interface DispatchRepository {
+    fun save(dispatch: Dispatch): Long
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/repository/DispatchRequestRepository.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/domain/repository/DispatchRequestRepository.kt
@@ -4,4 +4,6 @@ import com.baro.dispatch.domain.model.DispatchRequest
 
 interface DispatchRequestRepository {
     fun save(request: DispatchRequest): Long
+
+    fun findById(requestId: Long): DispatchRequest?
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchEntity.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchEntity.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
 import java.time.Instant
@@ -20,7 +21,10 @@ import java.time.ZoneOffset
 private val DEFAULT_OFFSET_DATE_TIME: OffsetDateTime = OffsetDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC)
 
 @Entity
-@Table(name = "dispatch")
+@Table(
+    name = "dispatch",
+    uniqueConstraints = [UniqueConstraint(name = "uk_dispatch_request_id", columnNames = ["request_id"])],
+)
 class DispatchEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -66,6 +70,7 @@ class DispatchEntity(
     companion object {
         fun from(dispatch: Dispatch): DispatchEntity =
             DispatchEntity(
+                dispatchId = dispatch.id,
                 requestId = dispatch.requestId,
                 userId = dispatch.userId,
                 carId = dispatch.carId,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchEntity.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchEntity.kt
@@ -1,0 +1,84 @@
+package com.baro.dispatch.infrastructure.persistence
+
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.model.DispatchStatus
+import com.baro.dispatch.domain.model.GeoPoint
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+private val DEFAULT_OFFSET_DATE_TIME: OffsetDateTime = OffsetDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC)
+
+@Entity
+@Table(name = "dispatch")
+class DispatchEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dispatch_id")
+    var dispatchId: Long? = null,
+
+    @Column(name = "request_id", nullable = false)
+    var requestId: Long = 0,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long = 0,
+
+    @Column(name = "car_id", nullable = false)
+    var carId: Long = 0,
+
+    @Column(name = "stand_id", nullable = false)
+    var standId: Long = 0,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: OffsetDateTime = DEFAULT_OFFSET_DATE_TIME,
+
+    @Column(name = "estimated_pickup_time", nullable = false)
+    var estimatedPickupTime: Int = 0,
+
+    @Column(name = "estimated_ride_time", nullable = false)
+    var estimatedRideTime: Int = 0,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "pickup_route_path", nullable = false)
+    var pickupRoutePath: List<List<Double>> = emptyList(),
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "dropoff_route_path", nullable = false)
+    var dropoffRoutePath: List<List<Double>> = emptyList(),
+
+    @Column(nullable = false)
+    var fare: Int = 0,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dispatch_status", nullable = false)
+    var status: DispatchStatus = DispatchStatus.REQUESTED,
+) {
+    companion object {
+        fun from(dispatch: Dispatch): DispatchEntity =
+            DispatchEntity(
+                requestId = dispatch.requestId,
+                userId = dispatch.userId,
+                carId = dispatch.carId,
+                standId = dispatch.standId,
+                createdAt = dispatch.createdAt,
+                estimatedPickupTime = dispatch.estimatedPickupTime,
+                estimatedRideTime = dispatch.estimatedRideTime,
+                pickupRoutePath = dispatch.pickupRoutePath.toRoutePath(),
+                dropoffRoutePath = dispatch.dropoffRoutePath.toRoutePath(),
+                fare = dispatch.fare,
+                status = dispatch.status,
+            )
+
+        private fun List<GeoPoint>.toRoutePath(): List<List<Double>> = map { listOf(it.longitude, it.latitude) }
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchJpaRepository.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchJpaRepository.kt
@@ -1,0 +1,5 @@
+package com.baro.dispatch.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DispatchJpaRepository : JpaRepository<DispatchEntity, Long>

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRepositoryAdapter.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRepositoryAdapter.kt
@@ -1,0 +1,13 @@
+package com.baro.dispatch.infrastructure.persistence
+
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.repository.DispatchRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class DispatchRepositoryAdapter(
+    private val repo: DispatchJpaRepository,
+) : DispatchRepository {
+    override fun save(dispatch: Dispatch): Long =
+        requireNotNull(repo.save(DispatchEntity.from(dispatch)).dispatchId) { "배차 ID 생성에 실패했습니다." }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRequestEntity.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRequestEntity.kt
@@ -14,7 +14,11 @@ import jakarta.persistence.Table
 import org.hibernate.annotations.ColumnTransformer
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+private val DEFAULT_OFFSET_DATE_TIME: OffsetDateTime = OffsetDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC)
 
 @Entity
 @Table(name = "dispatch_request")
@@ -67,15 +71,29 @@ class DispatchRequestEntity(
     var distanceKm: Double = 0.0,
 
     @Column(name = "requested_at", nullable = false)
-    var requestedAt: OffsetDateTime = OffsetDateTime.now(),
+    var requestedAt: OffsetDateTime = DEFAULT_OFFSET_DATE_TIME,
 
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: OffsetDateTime = OffsetDateTime.now(),
+    var updatedAt: OffsetDateTime = DEFAULT_OFFSET_DATE_TIME,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "dispatch_request_status", nullable = false)
     var status: DispatchRequestStatus = DispatchRequestStatus.PENDING,
 ) {
+    fun toDomain(): DispatchRequest =
+        DispatchRequest(
+            userId = userId,
+            origin = GeoPoint(longitude = startLongitude, latitude = startLatitude, name = startName),
+            destination = GeoPoint(longitude = endLongitude, latitude = endLatitude, name = endName),
+            status = status,
+            fare = fare,
+            routePath = routePath.map { GeoPoint(longitude = it[0], latitude = it[1]) },
+            estimatedTime = estimatedTime,
+            distanceKm = distanceKm,
+            requestedAt = requestedAt,
+            updatedAt = updatedAt,
+        )
+
     companion object {
         fun from(request: DispatchRequest): DispatchRequestEntity =
             DispatchRequestEntity(

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRequestEntity.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRequestEntity.kt
@@ -82,6 +82,7 @@ class DispatchRequestEntity(
 ) {
     fun toDomain(): DispatchRequest =
         DispatchRequest(
+            id = requestId,
             userId = userId,
             origin = GeoPoint(longitude = startLongitude, latitude = startLatitude, name = startName),
             destination = GeoPoint(longitude = endLongitude, latitude = endLatitude, name = endName),
@@ -97,6 +98,7 @@ class DispatchRequestEntity(
     companion object {
         fun from(request: DispatchRequest): DispatchRequestEntity =
             DispatchRequestEntity(
+                requestId = request.id,
                 userId = request.userId,
                 startLatitude = request.origin.latitude,
                 startLongitude = request.origin.longitude,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRequestRepositoryAdapter.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchRequestRepositoryAdapter.kt
@@ -10,4 +10,6 @@ class DispatchRequestRepositoryAdapter(
 ) : DispatchRequestRepository {
     override fun save(request: DispatchRequest): Long =
         requireNotNull(repo.save(DispatchRequestEntity.from(request)).requestId) { "배차 요청 ID 생성에 실패했습니다." }
+
+    override fun findById(requestId: Long): DispatchRequest? = repo.findById(requestId).map { it.toDomain() }.orElse(null)
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchController.kt
@@ -1,0 +1,35 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.common.web.response.BaseResponse
+import com.baro.dispatch.application.service.ConfirmDispatchService
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(DispatchApiPaths.DISPATCH)
+class ConfirmDispatchController(
+    private val confirmDispatchService: ConfirmDispatchService,
+) {
+    @Operation(
+        summary = "배차 요청",
+        description = "PRE배차 요청 ID를 기반으로 실제 배차 요청을 생성합니다. 차량 조회/배정은 임시 값으로 처리합니다.",
+    )
+    @PostMapping
+    fun confirm(
+        @RequestBody request: ConfirmDispatchRequest,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): BaseResponse<ConfirmDispatchResponse> {
+        val authenticatedUserId = jwt.subject?.toLongOrNull()
+        if (authenticatedUserId != request.userId) {
+            throw AccessDeniedException("요청 사용자와 인증 사용자가 일치하지 않습니다.")
+        }
+
+        return BaseResponse.success(ConfirmDispatchResponse.from(confirmDispatchService.confirm(request.toCommand())))
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
@@ -1,0 +1,56 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.dispatch.application.service.ConfirmDispatchCommand
+import com.baro.dispatch.application.service.ConfirmDispatchResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ConfirmDispatchRequest(
+    @field:Schema(description = "PRE배차 요청 ID", example = "1")
+    val requestId: Long,
+    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    val userId: Long,
+) {
+    fun toCommand(): ConfirmDispatchCommand = ConfirmDispatchCommand(requestId = requestId, userId = userId)
+}
+
+data class ConfirmDispatchResponse(
+    @field:Schema(description = "배차 ID", example = "1")
+    val dispatchId: Long,
+    @field:Schema(description = "PRE배차 요청 ID", example = "1")
+    val requestId: Long,
+    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    val userId: Long,
+    @field:Schema(description = "임시 차량 ID", example = "0")
+    val carId: Long,
+    @field:Schema(description = "임시 승차장 ID", example = "0")
+    val standId: Long,
+    @field:Schema(description = "예상 픽업 시간(분)", example = "0")
+    val estimatedPickupTime: Int,
+    @field:Schema(description = "예상 운행 시간(분)", example = "46")
+    val estimatedRideTime: Int,
+    @field:Schema(description = "픽업 경로 좌표 목록 [경도, 위도]")
+    val pickupRoutePath: List<List<Double>>,
+    @field:Schema(description = "목적지 경로 좌표 목록 [경도, 위도]")
+    val dropoffRoutePath: List<List<Double>>,
+    @field:Schema(description = "요금", example = "12100")
+    val fare: Int,
+    @field:Schema(description = "배차 상태", example = "REQUESTED")
+    val dispatchStatus: String,
+) {
+    companion object {
+        fun from(result: ConfirmDispatchResult): ConfirmDispatchResponse =
+            ConfirmDispatchResponse(
+                dispatchId = result.dispatchId,
+                requestId = result.requestId,
+                userId = result.userId,
+                carId = result.carId,
+                standId = result.standId,
+                estimatedPickupTime = result.estimatedPickupTime,
+                estimatedRideTime = result.estimatedRideTime,
+                pickupRoutePath = result.pickupRoutePath.map { listOf(it.longitude, it.latitude) },
+                dropoffRoutePath = result.dropoffRoutePath.map { listOf(it.longitude, it.latitude) },
+                fare = result.fare,
+                dispatchStatus = result.status,
+            )
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchApiPaths.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchApiPaths.kt
@@ -4,4 +4,5 @@ object DispatchApiPaths {
     const val DISPATCH = "/dispatch"
     const val PRE_DISPATCH = "/pre"
     const val PRE_DISPATCH_FULL = "$DISPATCH$PRE_DISPATCH"
+    const val CONFIRM_DISPATCH_FULL = DISPATCH
 }

--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
@@ -1,0 +1,82 @@
+package com.baro.dispatch.application.service
+
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.model.DispatchRequest
+import com.baro.dispatch.domain.model.GeoPoint
+import com.baro.dispatch.domain.repository.DispatchRepository
+import com.baro.dispatch.domain.repository.DispatchRequestRepository
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ConfirmDispatchServiceTest {
+    @Test
+    fun `PRE배차 요청 ID로 실제 배차 요청을 생성한다`() {
+        var savedDispatch: Dispatch? = null
+        val preRequest = DispatchRequest.pending(
+            userId = 2L,
+            origin = GeoPoint(longitude = 127.1, latitude = 37.4),
+            destination = GeoPoint(longitude = 127.2, latitude = 37.5),
+            fare = 12_100,
+            routePath = listOf(GeoPoint(longitude = 127.11, latitude = 37.41)),
+            estimatedTime = 46,
+            distanceKm = 13.8,
+            now = OffsetDateTime.ofInstant(Instant.parse("2026-04-27T00:00:00Z"), ZoneOffset.UTC),
+        )
+        val service = ConfirmDispatchService(
+            dispatchRequestRepository = object : DispatchRequestRepository {
+                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun findById(requestId: Long): DispatchRequest? = preRequest.takeIf { requestId == 1L }
+            },
+            dispatchRepository = object : DispatchRepository {
+                override fun save(dispatch: Dispatch): Long {
+                    savedDispatch = dispatch
+                    return 10L
+                }
+            },
+            clock = Clock.fixed(Instant.parse("2026-04-27T01:00:00Z"), ZoneOffset.UTC),
+        )
+
+        val result = service.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))
+
+        assertEquals(10L, result.dispatchId)
+        assertEquals(1L, result.requestId)
+        assertEquals(2L, result.userId)
+        assertEquals(0L, result.carId)
+        assertEquals(0L, result.standId)
+        assertEquals(0, result.estimatedPickupTime)
+        assertEquals(46, result.estimatedRideTime)
+        assertEquals(emptyList(), result.pickupRoutePath)
+        assertEquals(preRequest.routePath, result.dropoffRoutePath)
+        assertEquals(12_100, result.fare)
+        assertEquals("REQUESTED", result.status)
+
+        val dispatch = requireNotNull(savedDispatch)
+        assertEquals(Instant.parse("2026-04-27T01:00:00Z"), dispatch.createdAt.toInstant())
+        assertEquals(preRequest.routePath, dispatch.dropoffRoutePath)
+    }
+
+    @Test
+    fun `PRE배차 요청이 없으면 예외를 던진다`() {
+        val service = ConfirmDispatchService(
+            dispatchRequestRepository = object : DispatchRequestRepository {
+                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun findById(requestId: Long): DispatchRequest? = null
+            },
+            dispatchRepository = object : DispatchRepository {
+                override fun save(dispatch: Dispatch): Long = error("사용하지 않습니다.")
+            },
+            clock = Clock.fixed(Instant.parse("2026-04-27T01:00:00Z"), ZoneOffset.UTC),
+        )
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))
+        }
+
+        assertEquals("PRE배차 요청을 찾을 수 없습니다.", exception.message)
+    }
+}

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
@@ -2,6 +2,7 @@ package com.baro.dispatch.application.service
 
 import com.baro.dispatch.domain.model.Dispatch
 import com.baro.dispatch.domain.model.DispatchRequest
+import com.baro.dispatch.domain.model.DispatchRequestStatus
 import com.baro.dispatch.domain.model.GeoPoint
 import com.baro.dispatch.domain.repository.DispatchRepository
 import com.baro.dispatch.domain.repository.DispatchRequestRepository
@@ -17,6 +18,7 @@ class ConfirmDispatchServiceTest {
     @Test
     fun `PRE배차 요청 ID로 실제 배차 요청을 생성한다`() {
         var savedDispatch: Dispatch? = null
+        var updatedPreRequest: DispatchRequest? = null
         val preRequest = DispatchRequest.pending(
             userId = 2L,
             origin = GeoPoint(longitude = 127.1, latitude = 37.4),
@@ -26,10 +28,14 @@ class ConfirmDispatchServiceTest {
             estimatedTime = 46,
             distanceKm = 13.8,
             now = OffsetDateTime.ofInstant(Instant.parse("2026-04-27T00:00:00Z"), ZoneOffset.UTC),
-        )
+        ).copy(id = 1L)
         val service = ConfirmDispatchService(
             dispatchRequestRepository = object : DispatchRequestRepository {
-                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun save(request: DispatchRequest): Long {
+                    updatedPreRequest = request
+                    return requireNotNull(request.id)
+                }
+
                 override fun findById(requestId: Long): DispatchRequest? = preRequest.takeIf { requestId == 1L }
             },
             dispatchRepository = object : DispatchRepository {
@@ -38,7 +44,7 @@ class ConfirmDispatchServiceTest {
                     return 10L
                 }
             },
-            clock = Clock.fixed(Instant.parse("2026-04-27T01:00:00Z"), ZoneOffset.UTC),
+            clock = Clock.fixed(Instant.parse("2026-04-27T00:05:00Z"), ZoneOffset.UTC),
         )
 
         val result = service.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))
@@ -56,8 +62,10 @@ class ConfirmDispatchServiceTest {
         assertEquals("REQUESTED", result.status)
 
         val dispatch = requireNotNull(savedDispatch)
-        assertEquals(Instant.parse("2026-04-27T01:00:00Z"), dispatch.createdAt.toInstant())
+        assertEquals(Instant.parse("2026-04-27T00:05:00Z"), dispatch.createdAt.toInstant())
         assertEquals(preRequest.routePath, dispatch.dropoffRoutePath)
+        assertEquals(DispatchRequestStatus.MATCHED, requireNotNull(updatedPreRequest).status)
+        assertEquals(Instant.parse("2026-04-27T00:05:00Z"), requireNotNull(updatedPreRequest).updatedAt.toInstant())
     }
 
     @Test
@@ -78,5 +86,65 @@ class ConfirmDispatchServiceTest {
         }
 
         assertEquals("PRE배차 요청을 찾을 수 없습니다.", exception.message)
+    }
+
+    @Test
+    fun `이미 처리된 PRE배차 요청이면 예외를 던진다`() {
+        val preRequest = DispatchRequest.pending(
+            userId = 2L,
+            origin = GeoPoint(longitude = 127.1, latitude = 37.4),
+            destination = GeoPoint(longitude = 127.2, latitude = 37.5),
+            fare = 12_100,
+            routePath = emptyList(),
+            estimatedTime = 46,
+            distanceKm = 13.8,
+            now = OffsetDateTime.ofInstant(Instant.parse("2026-04-27T00:00:00Z"), ZoneOffset.UTC),
+        ).copy(id = 1L, status = DispatchRequestStatus.MATCHED)
+        val service = ConfirmDispatchService(
+            dispatchRequestRepository = object : DispatchRequestRepository {
+                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun findById(requestId: Long): DispatchRequest? = preRequest
+            },
+            dispatchRepository = object : DispatchRepository {
+                override fun save(dispatch: Dispatch): Long = error("사용하지 않습니다.")
+            },
+            clock = Clock.fixed(Instant.parse("2026-04-27T00:05:00Z"), ZoneOffset.UTC),
+        )
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))
+        }
+
+        assertEquals("이미 처리된 PRE배차 요청입니다.", exception.message)
+    }
+
+    @Test
+    fun `만료된 PRE배차 요청이면 예외를 던진다`() {
+        val preRequest = DispatchRequest.pending(
+            userId = 2L,
+            origin = GeoPoint(longitude = 127.1, latitude = 37.4),
+            destination = GeoPoint(longitude = 127.2, latitude = 37.5),
+            fare = 12_100,
+            routePath = emptyList(),
+            estimatedTime = 46,
+            distanceKm = 13.8,
+            now = OffsetDateTime.ofInstant(Instant.parse("2026-04-27T00:00:00Z"), ZoneOffset.UTC),
+        ).copy(id = 1L)
+        val service = ConfirmDispatchService(
+            dispatchRequestRepository = object : DispatchRequestRepository {
+                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun findById(requestId: Long): DispatchRequest? = preRequest
+            },
+            dispatchRepository = object : DispatchRepository {
+                override fun save(dispatch: Dispatch): Long = error("사용하지 않습니다.")
+            },
+            clock = Clock.fixed(Instant.parse("2026-04-27T00:10:01Z"), ZoneOffset.UTC),
+        )
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))
+        }
+
+        assertEquals("만료된 PRE배차 요청입니다.", exception.message)
     }
 }

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/PreDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/PreDispatchServiceTest.kt
@@ -36,6 +36,8 @@ class PreDispatchServiceTest {
                     savedRequest = request
                     return 1L
                 }
+
+                override fun findById(requestId: Long): DispatchRequest? = null
             },
             clock = Clock.fixed(Instant.parse("2026-04-27T00:00:00Z"), ZoneOffset.UTC),
         )

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchControllerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchControllerTest.kt
@@ -1,0 +1,101 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.common.web.config.CommonJacksonConfig
+import com.baro.common.web.error.CommonRestExceptionHandler
+import com.baro.dispatch.application.service.ConfirmDispatchResult
+import com.baro.dispatch.application.service.ConfirmDispatchService
+import com.baro.dispatch.application.service.ConfirmDispatchCommand
+import com.baro.dispatch.domain.model.GeoPoint
+import com.baro.dispatch.infrastructure.security.SecurityConfig
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.Instant
+
+@WebMvcTest(ConfirmDispatchController::class)
+@Import(CommonJacksonConfig::class, CommonRestExceptionHandler::class, DispatchRestExceptionHandler::class, SecurityConfig::class)
+class ConfirmDispatchControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var confirmDispatchService: ConfirmDispatchService
+
+    @MockBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Test
+    fun `인증된 배차 요청 시 배차 정보를 반환한다`() {
+        given(jwtDecoder.decode("access-token")).willReturn(`인증 토큰`())
+        given(confirmDispatchService.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))).willReturn(
+            ConfirmDispatchResult(
+                dispatchId = 10L,
+                requestId = 1L,
+                userId = 2L,
+                carId = 0L,
+                standId = 0L,
+                estimatedPickupTime = 0,
+                estimatedRideTime = 46,
+                pickupRoutePath = emptyList(),
+                dropoffRoutePath = listOf(GeoPoint(longitude = 127.1, latitude = 37.4)),
+                fare = 12_100,
+                status = "REQUESTED",
+            ),
+        )
+
+        mockMvc.post(DispatchApiPaths.CONFIRM_DISPATCH_FULL) {
+            contentType = MediaType.APPLICATION_JSON
+            header("Authorization", "Bearer access-token")
+            content = """{"request_id":1,"user_id":2}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.dispatch_id") { value(10) }
+            jsonPath("$.data.request_id") { value(1) }
+            jsonPath("$.data.dispatch_status") { value("REQUESTED") }
+        }
+    }
+
+    @Test
+    fun `배차 요청 시 엑세스 토큰이 없으면 인증 오류를 반환한다`() {
+        mockMvc.post(DispatchApiPaths.CONFIRM_DISPATCH_FULL) {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"request_id":1,"user_id":2}"""
+        }.andExpect {
+            status { isUnauthorized() }
+            jsonPath("$.error.code") { value("UNAUTHORIZED") }
+        }
+    }
+
+    @Test
+    fun `배차 요청 사용자와 인증 사용자가 다르면 접근 권한 오류를 반환한다`() {
+        given(jwtDecoder.decode("access-token")).willReturn(`인증 토큰`())
+
+        mockMvc.post(DispatchApiPaths.CONFIRM_DISPATCH_FULL) {
+            contentType = MediaType.APPLICATION_JSON
+            header("Authorization", "Bearer access-token")
+            content = """{"request_id":1,"user_id":3}"""
+        }.andExpect {
+            status { isForbidden() }
+            jsonPath("$.error.code") { value("FORBIDDEN") }
+            jsonPath("$.error.message") { value("요청 사용자와 인증 사용자가 일치하지 않습니다.") }
+        }
+    }
+
+    private fun `인증 토큰`(): Jwt =
+        Jwt.withTokenValue("access-token")
+            .header("alg", "HS256")
+            .subject("2")
+            .claim("email", "user@example.com")
+            .issuedAt(Instant.parse("2026-04-27T00:00:00Z"))
+            .expiresAt(Instant.parse("2026-04-27T00:15:00Z"))
+            .build()
+}


### PR DESCRIPTION
## 작업 내용
- PRE배차 요청 ID 기반 실제 배차 요청 API 추가
- POST /dispatch 인증/인가 적용
- 차량/승차장 조회는 TODO로 남기고 임시 carId/standId 0 저장
- dispatch 도메인, JPA 엔티티, 저장소 추가
- PRE배차 이력 조회용 repository 메서드 추가
- PR 17 리뷰 반영: 기본 ddl-auto validate, 서비스 트랜잭션 추가, 엔티티 기본 시간값 개선

## 검증
- ./gradlew :dispatch-service:build --no-daemon