### PR TITLE
ci: deploy dispatch service to dev ECS

### DIFF
--- a/.github/workflows/deploy-dev-ecs.yml
+++ b/.github/workflows/deploy-dev-ecs.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - all
+          - dispatch
           - user
   push:
     branches:
@@ -26,6 +27,7 @@ on:
       - common-kakao/**
       - common-security/**
       - common-web/**
+      - dispatch-service/**
       - user-service/**
       - .github/workflows/deploy-dev-ecs.yml
 
@@ -45,6 +47,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - key: dispatch
+            module: dispatch-service
+            repository: baro-dev-dispatch-service
           - key: user
             module: user-service
             repository: baro-dev-user-service


### PR DESCRIPTION
## Summary
- add dispatch-service to the dev ECS deploy workflow
- allow manual workflow selection for dispatch
- trigger deploy workflow when dispatch-service changes

## Notes
- Terraform prepares dispatch ECS/ECR/ALB resources separately
- dispatch service should remain at desired count 0 until image and Kakao secret are ready

## Validation
- ./gradlew :dispatch-service:build