### PR TITLE
fix: allow dispatch swagger paths

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/security/SecurityConfig.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/security/SecurityConfig.kt
@@ -34,6 +34,10 @@ class SecurityConfig {
                 it.requestMatchers(
                     "/actuator/health",
                     "/api-docs/**",
+                    "/dispatch/api-docs/**",
+                    "/dispatch/api-docs",
+                    "/dispatch/swagger-ui/**",
+                    "/dispatch/swagger-ui.html",
                     "/swagger-ui/**",
                     "/swagger-ui.html",
                 ).permitAll().anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- allow /dispatch/swagger-ui.html and /dispatch/swagger-ui/** without auth
- allow /dispatch/api-docs and /dispatch/api-docs/** without auth

## Validation
- ./gradlew :dispatch-service:build