### PR TITLE
fix: document dispatch DTO snake case

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
@@ -2,39 +2,52 @@ package com.baro.dispatch.interfaces.rest
 
 import com.baro.dispatch.application.service.ConfirmDispatchCommand
 import com.baro.dispatch.application.service.ConfirmDispatchResult
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ConfirmDispatchRequest(
-    @field:Schema(description = "PRE배차 요청 ID", example = "1")
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "PRE배차 요청 ID", example = "1")
     val requestId: Long,
-    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    @field:JsonProperty("user_id")
+    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
     val userId: Long,
 ) {
     fun toCommand(): ConfirmDispatchCommand = ConfirmDispatchCommand(requestId = requestId, userId = userId)
 }
 
 data class ConfirmDispatchResponse(
-    @field:Schema(description = "배차 ID", example = "1")
+    @field:JsonProperty("dispatch_id")
+    @field:Schema(name = "dispatch_id", description = "배차 ID", example = "1")
     val dispatchId: Long,
-    @field:Schema(description = "PRE배차 요청 ID", example = "1")
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "PRE배차 요청 ID", example = "1")
     val requestId: Long,
-    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    @field:JsonProperty("user_id")
+    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
     val userId: Long,
-    @field:Schema(description = "임시 차량 ID", example = "0")
+    @field:JsonProperty("car_id")
+    @field:Schema(name = "car_id", description = "임시 차량 ID", example = "0")
     val carId: Long,
-    @field:Schema(description = "임시 승차장 ID", example = "0")
+    @field:JsonProperty("stand_id")
+    @field:Schema(name = "stand_id", description = "임시 승차장 ID", example = "0")
     val standId: Long,
-    @field:Schema(description = "예상 픽업 시간(분)", example = "0")
+    @field:JsonProperty("estimated_pickup_time")
+    @field:Schema(name = "estimated_pickup_time", description = "예상 픽업 시간(분)", example = "0")
     val estimatedPickupTime: Int,
-    @field:Schema(description = "예상 운행 시간(분)", example = "46")
+    @field:JsonProperty("estimated_ride_time")
+    @field:Schema(name = "estimated_ride_time", description = "예상 운행 시간(분)", example = "46")
     val estimatedRideTime: Int,
-    @field:Schema(description = "픽업 경로 좌표 목록 [경도, 위도]")
+    @field:JsonProperty("pickup_route_path")
+    @field:Schema(name = "pickup_route_path", description = "픽업 경로 좌표 목록 [경도, 위도]")
     val pickupRoutePath: List<List<Double>>,
-    @field:Schema(description = "목적지 경로 좌표 목록 [경도, 위도]")
+    @field:JsonProperty("dropoff_route_path")
+    @field:Schema(name = "dropoff_route_path", description = "목적지 경로 좌표 목록 [경도, 위도]")
     val dropoffRoutePath: List<List<Double>>,
     @field:Schema(description = "요금", example = "12100")
     val fare: Int,
-    @field:Schema(description = "배차 상태", example = "REQUESTED")
+    @field:JsonProperty("dispatch_status")
+    @field:Schema(name = "dispatch_status", description = "배차 상태", example = "REQUESTED")
     val dispatchStatus: String,
 ) {
     companion object {

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
@@ -3,10 +3,12 @@ package com.baro.dispatch.interfaces.rest
 import com.baro.dispatch.application.service.PreDispatchCommand
 import com.baro.dispatch.application.service.PreDispatchResult
 import com.baro.dispatch.domain.model.GeoPoint
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PreDispatchRequest(
-    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    @field:JsonProperty("user_id")
+    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
     val userId: Long,
     @field:Schema(description = "출발지 정보")
     val origin: LocationPointRequest,
@@ -33,18 +35,23 @@ data class LocationPointRequest(
 }
 
 data class PreDispatchResponse(
-    @field:Schema(description = "요청 ID", example = "1")
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "요청 ID", example = "1")
     val requestId: Long,
     @field:Schema(description = "예상 요금", example = "18500")
     val fare: Int,
+    @field:JsonProperty("route_path")
     @field:Schema(
+        name = "route_path",
         description = "경로 좌표 목록 [경도, 위도]",
         example = "[[127.091896,37.547],[126.925011,37.551464]]",
     )
     val routePath: List<List<Double>>,
-    @field:Schema(description = "예상 소요 시간(초)", example = "2140")
+    @field:JsonProperty("estimated_time")
+    @field:Schema(name = "estimated_time", description = "예상 소요 시간(초)", example = "2140")
     val estimatedTime: Int,
-    @field:Schema(description = "거리(km)", example = "15.8")
+    @field:JsonProperty("distance_km")
+    @field:Schema(name = "distance_km", description = "거리(km)", example = "15.8")
     val distanceKm: Double,
 ) {
     companion object {

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
@@ -48,7 +48,7 @@ data class PreDispatchResponse(
     )
     val routePath: List<List<Double>>,
     @field:JsonProperty("estimated_time")
-    @field:Schema(name = "estimated_time", description = "예상 소요 시간(초)", example = "2140")
+    @field:Schema(name = "estimated_time", description = "예상 소요 시간(분)", example = "36")
     val estimatedTime: Int,
     @field:JsonProperty("distance_km")
     @field:Schema(name = "distance_km", description = "거리(km)", example = "15.8")


### PR DESCRIPTION
## Summary
- align dispatch Swagger request/response field names with actual snake_case JSON
- document request_id/user_id instead of requestId/userId
- add explicit JsonProperty annotations for dispatch DTOs

## Validation
- ./gradlew :dispatch-service:build
- E2E 확인: requestId/userId는 403, request_id/user_id는 200