### PR TITLE
fix: derive dispatch user from JWT

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchController.kt
@@ -26,10 +26,8 @@ class ConfirmDispatchController(
         @AuthenticationPrincipal jwt: Jwt,
     ): BaseResponse<ConfirmDispatchResponse> {
         val authenticatedUserId = jwt.subject?.toLongOrNull()
-        if (authenticatedUserId != request.userId) {
-            throw AccessDeniedException("요청 사용자와 인증 사용자가 일치하지 않습니다.")
-        }
+            ?: throw AccessDeniedException("인증 사용자 정보가 올바르지 않습니다.")
 
-        return BaseResponse.success(ConfirmDispatchResponse.from(confirmDispatchService.confirm(request.toCommand())))
+        return BaseResponse.success(ConfirmDispatchResponse.from(confirmDispatchService.confirm(request.toCommand(authenticatedUserId))))
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
@@ -9,11 +9,8 @@ data class ConfirmDispatchRequest(
     @field:JsonProperty("request_id")
     @field:Schema(name = "request_id", description = "PRE배차 요청 ID", example = "1")
     val requestId: Long,
-    @field:JsonProperty("user_id")
-    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
-    val userId: Long,
 ) {
-    fun toCommand(): ConfirmDispatchCommand = ConfirmDispatchCommand(requestId = requestId, userId = userId)
+    fun toCommand(userId: Long): ConfirmDispatchCommand = ConfirmDispatchCommand(requestId = requestId, userId = userId)
 }
 
 data class ConfirmDispatchResponse(

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchDtos.kt
@@ -2,39 +2,52 @@ package com.baro.dispatch.interfaces.rest
 
 import com.baro.dispatch.application.service.ConfirmDispatchCommand
 import com.baro.dispatch.application.service.ConfirmDispatchResult
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ConfirmDispatchRequest(
-    @field:Schema(description = "PRE배차 요청 ID", example = "1")
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "PRE배차 요청 ID", example = "1")
     val requestId: Long,
-    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    @field:JsonProperty("user_id")
+    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
     val userId: Long,
 ) {
     fun toCommand(): ConfirmDispatchCommand = ConfirmDispatchCommand(requestId = requestId, userId = userId)
 }
 
 data class ConfirmDispatchResponse(
-    @field:Schema(description = "배차 ID", example = "1")
+    @field:JsonProperty("dispatch_id")
+    @field:Schema(name = "dispatch_id", description = "배차 ID", example = "1")
     val dispatchId: Long,
-    @field:Schema(description = "PRE배차 요청 ID", example = "1")
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "PRE배차 요청 ID", example = "1")
     val requestId: Long,
-    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    @field:JsonProperty("user_id")
+    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
     val userId: Long,
-    @field:Schema(description = "임시 차량 ID", example = "0")
+    @field:JsonProperty("car_id")
+    @field:Schema(name = "car_id", description = "임시 차량 ID", example = "0")
     val carId: Long,
-    @field:Schema(description = "임시 승차장 ID", example = "0")
+    @field:JsonProperty("stand_id")
+    @field:Schema(name = "stand_id", description = "임시 승차장 ID", example = "0")
     val standId: Long,
-    @field:Schema(description = "예상 픽업 시간(분)", example = "0")
+    @field:JsonProperty("estimated_pickup_time")
+    @field:Schema(name = "estimated_pickup_time", description = "예상 픽업 시간(분)", example = "0")
     val estimatedPickupTime: Int,
-    @field:Schema(description = "예상 운행 시간(분)", example = "46")
+    @field:JsonProperty("estimated_ride_time")
+    @field:Schema(name = "estimated_ride_time", description = "예상 운행 시간(분)", example = "46")
     val estimatedRideTime: Int,
-    @field:Schema(description = "픽업 경로 좌표 목록 [경도, 위도]")
+    @field:JsonProperty("pickup_route_path")
+    @field:Schema(name = "pickup_route_path", description = "픽업 경로 좌표 목록 [경도, 위도]")
     val pickupRoutePath: List<List<Double>>,
-    @field:Schema(description = "목적지 경로 좌표 목록 [경도, 위도]")
+    @field:JsonProperty("dropoff_route_path")
+    @field:Schema(name = "dropoff_route_path", description = "목적지 경로 좌표 목록 [경도, 위도]")
     val dropoffRoutePath: List<List<Double>>,
     @field:Schema(description = "요금", example = "12100")
     val fare: Int,
-    @field:Schema(description = "배차 상태", example = "REQUESTED")
+    @field:JsonProperty("dispatch_status")
+    @field:Schema(name = "dispatch_status", description = "배차 상태", example = "REQUESTED")
     val dispatchStatus: String,
 ) {
     companion object {

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchController.kt
@@ -35,7 +35,6 @@ class PreDispatchController(
                             name = "건국대 -> 홍익대",
                             value = """
                                 {
-                                  "user_id": 1001,
                                   "origin": {
                                     "lat": 37.547,
                                     "lon": 127.091896,
@@ -57,10 +56,8 @@ class PreDispatchController(
         @AuthenticationPrincipal jwt: Jwt,
     ): BaseResponse<PreDispatchResponse> {
         val authenticatedUserId = jwt.subject?.toLongOrNull()
-        if (authenticatedUserId != request.userId) {
-            throw AccessDeniedException("요청 사용자와 인증 사용자가 일치하지 않습니다.")
-        }
+            ?: throw AccessDeniedException("인증 사용자 정보가 올바르지 않습니다.")
 
-        return BaseResponse.success(PreDispatchResponse.from(preDispatchService.estimate(request.toCommand())))
+        return BaseResponse.success(PreDispatchResponse.from(preDispatchService.estimate(request.toCommand(authenticatedUserId))))
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
@@ -3,10 +3,12 @@ package com.baro.dispatch.interfaces.rest
 import com.baro.dispatch.application.service.PreDispatchCommand
 import com.baro.dispatch.application.service.PreDispatchResult
 import com.baro.dispatch.domain.model.GeoPoint
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PreDispatchRequest(
-    @field:Schema(description = "배차 요청 사용자 ID", example = "1001")
+    @field:JsonProperty("user_id")
+    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
     val userId: Long,
     @field:Schema(description = "출발지 정보")
     val origin: LocationPointRequest,
@@ -33,18 +35,23 @@ data class LocationPointRequest(
 }
 
 data class PreDispatchResponse(
-    @field:Schema(description = "요청 ID", example = "1")
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "요청 ID", example = "1")
     val requestId: Long,
     @field:Schema(description = "예상 요금", example = "18500")
     val fare: Int,
+    @field:JsonProperty("route_path")
     @field:Schema(
+        name = "route_path",
         description = "경로 좌표 목록 [경도, 위도]",
         example = "[[127.091896,37.547],[126.925011,37.551464]]",
     )
     val routePath: List<List<Double>>,
-    @field:Schema(description = "예상 소요 시간(초)", example = "2140")
+    @field:JsonProperty("estimated_time")
+    @field:Schema(name = "estimated_time", description = "예상 소요 시간(초)", example = "2140")
     val estimatedTime: Int,
-    @field:Schema(description = "거리(km)", example = "15.8")
+    @field:JsonProperty("distance_km")
+    @field:Schema(name = "distance_km", description = "거리(km)", example = "15.8")
     val distanceKm: Double,
 ) {
     companion object {

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchDtos.kt
@@ -7,15 +7,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PreDispatchRequest(
-    @field:JsonProperty("user_id")
-    @field:Schema(name = "user_id", description = "배차 요청 사용자 ID", example = "1001")
-    val userId: Long,
     @field:Schema(description = "출발지 정보")
     val origin: LocationPointRequest,
     @field:Schema(description = "도착지 정보")
     val destination: LocationPointRequest,
 ) {
-    fun toCommand(): PreDispatchCommand =
+    fun toCommand(userId: Long): PreDispatchCommand =
         PreDispatchCommand(
             userId = userId,
             origin = origin.toGeoPoint(),

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchControllerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/ConfirmDispatchControllerTest.kt
@@ -54,7 +54,7 @@ class ConfirmDispatchControllerTest {
         mockMvc.post(DispatchApiPaths.CONFIRM_DISPATCH_FULL) {
             contentType = MediaType.APPLICATION_JSON
             header("Authorization", "Bearer access-token")
-            content = """{"request_id":1,"user_id":2}"""
+            content = """{"request_id":1}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.success") { value(true) }
@@ -68,25 +68,10 @@ class ConfirmDispatchControllerTest {
     fun `배차 요청 시 엑세스 토큰이 없으면 인증 오류를 반환한다`() {
         mockMvc.post(DispatchApiPaths.CONFIRM_DISPATCH_FULL) {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"request_id":1,"user_id":2}"""
+            content = """{"request_id":1}"""
         }.andExpect {
             status { isUnauthorized() }
             jsonPath("$.error.code") { value("UNAUTHORIZED") }
-        }
-    }
-
-    @Test
-    fun `배차 요청 사용자와 인증 사용자가 다르면 접근 권한 오류를 반환한다`() {
-        given(jwtDecoder.decode("access-token")).willReturn(`인증 토큰`())
-
-        mockMvc.post(DispatchApiPaths.CONFIRM_DISPATCH_FULL) {
-            contentType = MediaType.APPLICATION_JSON
-            header("Authorization", "Bearer access-token")
-            content = """{"request_id":1,"user_id":3}"""
-        }.andExpect {
-            status { isForbidden() }
-            jsonPath("$.error.code") { value("FORBIDDEN") }
-            jsonPath("$.error.message") { value("요청 사용자와 인증 사용자가 일치하지 않습니다.") }
         }
     }
 

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchControllerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/PreDispatchControllerTest.kt
@@ -75,7 +75,6 @@ class PreDispatchControllerTest {
             header("Authorization", "Bearer access-token")
             content = """
                 {
-                  "user_id": 2,
                   "origin": {"lat": 37.402464820205246, "lon": 127.10764191124568},
                   "destination": {"lat": 37.39419693653072, "lon": 127.11056336672839}
                 }
@@ -98,7 +97,6 @@ class PreDispatchControllerTest {
             contentType = MediaType.APPLICATION_JSON
             content = """
                 {
-                  "user_id": 2,
                   "origin": {"lat": 37.402464820205246, "lon": 127.10764191124568},
                   "destination": {"lat": 37.39419693653072, "lon": 127.11056336672839}
                 }
@@ -108,28 +106,6 @@ class PreDispatchControllerTest {
             jsonPath("$.success") { value(false) }
             jsonPath("$.error.code") { value("UNAUTHORIZED") }
             jsonPath("$.error.message") { value("인증이 필요합니다.") }
-        }
-    }
-
-    @Test
-    fun `PRE배차 요청 사용자와 인증 사용자가 다르면 접근 권한 오류를 반환한다`() {
-        given(jwtDecoder.decode("access-token")).willReturn(`인증 토큰`())
-
-        mockMvc.post(DispatchApiPaths.PRE_DISPATCH_FULL) {
-            contentType = MediaType.APPLICATION_JSON
-            header("Authorization", "Bearer access-token")
-            content = """
-                {
-                  "user_id": 3,
-                  "origin": {"lat": 37.402464820205246, "lon": 127.10764191124568},
-                  "destination": {"lat": 37.39419693653072, "lon": 127.11056336672839}
-                }
-            """.trimIndent()
-        }.andExpect {
-            status { isForbidden() }
-            jsonPath("$.success") { value(false) }
-            jsonPath("$.error.code") { value("FORBIDDEN") }
-            jsonPath("$.error.message") { value("요청 사용자와 인증 사용자가 일치하지 않습니다.") }
         }
     }
 


### PR DESCRIPTION
## Summary
- remove user_id from PRE dispatch and dispatch confirm request bodies
- derive dispatch userId from authenticated JWT subject
- keep request/response Swagger field names aligned with snake_case JSON
- update controller tests for JWT-derived user ID

## Validation
- ./gradlew :dispatch-service:build