### PR TITLE
fix: user 경로와 오류 응답 정리

### DIFF
--- a/common-web/src/main/kotlin/com/baro/common/web/config/CommonCorsConfig.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/config/CommonCorsConfig.kt
@@ -1,0 +1,16 @@
+package com.baro.common.web.config
+
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@AutoConfiguration
+class CommonCorsConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .exposedHeaders("Location")
+    }
+}

--- a/common-web/src/main/kotlin/com/baro/common/web/config/CommonCorsConfig.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/config/CommonCorsConfig.kt
@@ -1,16 +1,29 @@
 package com.baro.common.web.config
 
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @AutoConfiguration
-class CommonCorsConfig : WebMvcConfigurer {
+@EnableConfigurationProperties(BaroCorsProperties::class)
+class CommonCorsConfig(
+    private val properties: BaroCorsProperties,
+) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
-            .allowedOriginPatterns("*")
+            .allowedOriginPatterns(*properties.allowedOriginPatterns.toTypedArray())
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .exposedHeaders("Location")
     }
 }
+
+@ConfigurationProperties(prefix = "baro.cors")
+data class BaroCorsProperties(
+    val allowedOriginPatterns: List<String> = listOf(
+        "https://dev.barocloud.com",
+        "http://localhost:*",
+    ),
+)

--- a/common-web/src/main/kotlin/com/baro/common/web/config/CommonOpenApiConfig.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/config/CommonOpenApiConfig.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -31,6 +32,7 @@ class CommonOpenApiConfig {
                     .description(properties.description)
                     .version(properties.version),
             )
+            .servers(listOf(Server().url(properties.serverUrl)))
 
     private companion object {
         const val BEARER_AUTH_SECURITY_SCHEME_NAME = "bearerAuth"
@@ -42,4 +44,5 @@ data class BaroOpenApiProperties(
     val title: String = "BARO API",
     val description: String = "BARO API documentation",
     val version: String = "v1",
+    val serverUrl: String = "/",
 )

--- a/common-web/src/main/kotlin/com/baro/common/web/error/CommonRestExceptionHandler.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/error/CommonRestExceptionHandler.kt
@@ -6,6 +6,8 @@ import com.baro.common.core.exception.ExternalServiceException
 import com.baro.common.web.response.BaseResponse
 import com.baro.common.web.response.ErrorCode
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -14,8 +16,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.RestClientException
 
 @AutoConfiguration
+@EnableConfigurationProperties(BaroErrorProperties::class)
 @RestControllerAdvice
-class CommonRestExceptionHandler {
+class CommonRestExceptionHandler(
+    private val properties: BaroErrorProperties,
+) {
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<BaseResponse<Nothing>> =
         ResponseEntity.badRequest().body(BaseResponse.error(ErrorCode.BAD_REQUEST, e.message ?: "잘못된 요청입니다."))
@@ -45,6 +50,10 @@ class CommonRestExceptionHandler {
             .body(BaseResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, serverErrorMessage(e)))
 
     private fun serverErrorMessage(e: Throwable): String {
+        if (!properties.includeDetails) {
+            return "서버 오류가 발생했습니다."
+        }
+
         val detail = generateSequence(e) { it.cause }
             .mapNotNull { it.message?.takeIf(String::isNotBlank) }
             .distinct()
@@ -53,3 +62,8 @@ class CommonRestExceptionHandler {
         return detail.ifBlank { "서버 오류가 발생했습니다." }
     }
 }
+
+@ConfigurationProperties(prefix = "baro.error")
+data class BaroErrorProperties(
+    val includeDetails: Boolean = false,
+)

--- a/common-web/src/main/kotlin/com/baro/common/web/error/CommonRestExceptionHandler.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/error/CommonRestExceptionHandler.kt
@@ -37,10 +37,19 @@ class CommonRestExceptionHandler {
     @ExceptionHandler(BaroException::class)
     fun handleBaroException(e: BaroException): ResponseEntity<BaseResponse<Nothing>> =
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(BaseResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, e.message ?: "서버 오류가 발생했습니다."))
+            .body(BaseResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, serverErrorMessage(e)))
 
     @ExceptionHandler(Exception::class)
     fun handleException(e: Exception): ResponseEntity<BaseResponse<Nothing>> =
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(BaseResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."))
+            .body(BaseResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, serverErrorMessage(e)))
+
+    private fun serverErrorMessage(e: Throwable): String {
+        val detail = generateSequence(e) { it.cause }
+            .mapNotNull { it.message?.takeIf(String::isNotBlank) }
+            .distinct()
+            .joinToString(" | ")
+
+        return detail.ifBlank { "서버 오류가 발생했습니다." }
+    }
 }

--- a/common-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,5 @@
 com.baro.common.web.config.CommonJacksonConfig
+com.baro.common.web.config.CommonCorsConfig
 com.baro.common.web.config.CommonOpenApiConfig
 com.baro.common.web.config.CommonTimeConfig
 com.baro.common.web.error.CommonRestExceptionHandler

--- a/common-web/src/test/kotlin/com/baro/common/web/config/CommonOpenApiConfigTest.kt
+++ b/common-web/src/test/kotlin/com/baro/common/web/config/CommonOpenApiConfigTest.kt
@@ -31,4 +31,20 @@ class CommonOpenApiConfigTest {
         assertEquals("bearer", securityScheme.scheme)
         assertEquals("JWT", securityScheme.bearerFormat)
     }
+
+    @Test
+    fun `공통 OpenAPI 설정은 기본 서버 URL을 현재 origin 기준으로 설정한다`() {
+        val openApi = CommonOpenApiConfig().baroOpenApi(BaroOpenApiProperties())
+
+        assertEquals("/", openApi.servers.single().url)
+    }
+
+    @Test
+    fun `공통 OpenAPI 설정은 외부 서버 URL을 반영한다`() {
+        val openApi = CommonOpenApiConfig().baroOpenApi(
+            BaroOpenApiProperties(serverUrl = "https://dev.barocloud.com"),
+        )
+
+        assertEquals("https://dev.barocloud.com", openApi.servers.single().url)
+    }
 }

--- a/common-web/src/test/kotlin/com/baro/common/web/error/CommonRestExceptionHandlerTest.kt
+++ b/common-web/src/test/kotlin/com/baro/common/web/error/CommonRestExceptionHandlerTest.kt
@@ -10,7 +10,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class CommonRestExceptionHandlerTest {
-    private val handler = CommonRestExceptionHandler()
+    private val handler = CommonRestExceptionHandler(BaroErrorProperties(includeDetails = false))
+    private val detailHandler = CommonRestExceptionHandler(BaroErrorProperties(includeDetails = true))
 
     @Test
     fun `잘못된 요청 예외는 400 응답으로 변환한다`() {
@@ -39,12 +40,12 @@ class CommonRestExceptionHandlerTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertFalse(response.body?.success ?: true)
         assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.name, response.body?.error?.code)
-        assertEquals("회원 저장에 실패했습니다.", response.body?.error?.message)
+        assertEquals("서버 오류가 발생했습니다.", response.body?.error?.message)
     }
 
     @Test
-    fun `처리되지 않은 일반 예외는 원인 예외 메시지도 함께 반환한다`() {
-        val response = handler.handleException(RuntimeException("회원가입 처리 실패", IllegalStateException("users 테이블이 없습니다.")))
+    fun `상세 오류 응답이 켜져 있으면 원인 예외 메시지도 함께 반환한다`() {
+        val response = detailHandler.handleException(RuntimeException("회원가입 처리 실패", IllegalStateException("users 테이블이 없습니다.")))
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertFalse(response.body?.success ?: true)

--- a/common-web/src/test/kotlin/com/baro/common/web/error/CommonRestExceptionHandlerTest.kt
+++ b/common-web/src/test/kotlin/com/baro/common/web/error/CommonRestExceptionHandlerTest.kt
@@ -39,7 +39,17 @@ class CommonRestExceptionHandlerTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertFalse(response.body?.success ?: true)
         assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.name, response.body?.error?.code)
-        assertEquals("서버 오류가 발생했습니다.", response.body?.error?.message)
+        assertEquals("회원 저장에 실패했습니다.", response.body?.error?.message)
+    }
+
+    @Test
+    fun `처리되지 않은 일반 예외는 원인 예외 메시지도 함께 반환한다`() {
+        val response = handler.handleException(RuntimeException("회원가입 처리 실패", IllegalStateException("users 테이블이 없습니다.")))
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertFalse(response.body?.success ?: true)
+        assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.name, response.body?.error?.code)
+        assertEquals("회원가입 처리 실패 | users 테이블이 없습니다.", response.body?.error?.message)
     }
 
     @Test

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/security/SecurityConfig.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/security/SecurityConfig.kt
@@ -28,6 +28,7 @@ class SecurityConfig {
         errorResponseWriter: SecurityErrorResponseWriter,
     ): SecurityFilterChain =
         http
+            .cors { }
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {

--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -31,6 +31,10 @@ springdoc:
     path: /swagger-ui.html
 
 baro:
+  error:
+    include-details: ${BARO_ERROR_INCLUDE_DETAILS:false}
+  cors:
+    allowed-origin-patterns: ${BARO_CORS_ALLOWED_ORIGIN_PATTERNS:https://dev.barocloud.com,http://localhost:*}
   openapi:
     title: Dispatch Service API
     description: BARO dispatch-service API documentation

--- a/user-service/src/main/kotlin/com/baro/user/infrastructure/security/SecurityConfig.kt
+++ b/user-service/src/main/kotlin/com/baro/user/infrastructure/security/SecurityConfig.kt
@@ -30,17 +30,22 @@ class SecurityConfig {
         errorResponseWriter: SecurityErrorResponseWriter,
     ): SecurityFilterChain =
         http
+            .cors { }
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it.requestMatchers(
                     "/actuator/health",
                     "/api-docs/**",
+                    "/user/api-docs/**",
+                    "/user/api-docs",
+                    "/user/swagger-ui/**",
+                    "/user/swagger-ui.html",
                     "/swagger-ui/**",
                     "/swagger-ui.html",
-                    "/auth/sign-up",
-                    "/auth/login",
-                    "/auth/token/refresh",
+                    "/user/auth/sign-up",
+                    "/user/auth/login",
+                    "/user/auth/token/refresh",
                 ).permitAll().anyRequest().authenticated()
             }
             .exceptionHandling {

--- a/user-service/src/main/kotlin/com/baro/user/interfaces/rest/AuthApiPaths.kt
+++ b/user-service/src/main/kotlin/com/baro/user/interfaces/rest/AuthApiPaths.kt
@@ -1,9 +1,11 @@
 package com.baro.user.interfaces.rest
 
 object AuthApiPaths {
-    const val SIGN_UP = "/auth/sign-up"
-    const val LOGIN = "/auth/login"
-    const val REFRESH = "/auth/token/refresh"
-    const val LOGOUT = "/auth/logout"
-    const val ME = "/users/me"
+    private const val USER_PREFIX = "/user"
+
+    const val SIGN_UP = "$USER_PREFIX/auth/sign-up"
+    const val LOGIN = "$USER_PREFIX/auth/login"
+    const val REFRESH = "$USER_PREFIX/auth/token/refresh"
+    const val LOGOUT = "$USER_PREFIX/auth/logout"
+    const val ME = "$USER_PREFIX/users/me"
 }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -31,6 +31,10 @@ springdoc:
     path: /user/swagger-ui.html
 
 baro:
+  error:
+    include-details: ${BARO_ERROR_INCLUDE_DETAILS:false}
+  cors:
+    allowed-origin-patterns: ${BARO_CORS_ALLOWED_ORIGIN_PATTERNS:https://dev.barocloud.com,http://localhost:*}
   openapi:
     title: User Service API
     description: BARO user-service API documentation

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -26,9 +26,9 @@ management:
 
 springdoc:
   api-docs:
-    path: /api-docs
+    path: /user/api-docs
   swagger-ui:
-    path: /swagger-ui.html
+    path: /user/swagger-ui.html
 
 baro:
   openapi:


### PR DESCRIPTION
## 변경사항
- user-service API/Swagger 경로를 /user prefix 기준으로 변경
  - /user/auth/sign-up
  - /user/auth/login
  - /user/auth/token/refresh
  - /user/auth/logout
  - /user/users/me
  - /user/swagger-ui.html
  - /user/api-docs
- OpenAPI server URL 기본값을 현재 origin 기준(/)으로 설정해 Swagger가 이전 ALB HTTP URL로 요청하지 않도록 수정
- common-web 공통 CORS 설정 추가 및 Spring Security CORS 활성화
- 공통 500 응답에 exception/cause 상세 메시지 포함

## 검증
- ./gradlew --no-daemon :common-web:test :user-service:test :dispatch-service:compileKotlin