### PR TITLE
fix: 가중치 데이터 - 정류장 위도, 경도 추가

### DIFF
--- a/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
@@ -9,9 +9,16 @@ data class StandWeightRequest(
 data class StandWeightDto(
     @JsonProperty("stand_id")
     val standId: String,
+
     @JsonProperty("time_zone")
     val timeZone: Int,
+
     @JsonProperty("day_of_week")
     val dayOfWeek: Int,
-    val weight: Double
+
+    val weight: Double,
+
+    val lat: Double,
+
+    val lon: Double
 )

--- a/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
@@ -18,7 +18,7 @@ data class StandWeightDto(
 
     val weight: Double,
 
-    val lat: Double,
+    val latitude: Double,
 
-    val lon: Double
+    val longitude: Double
 )

--- a/relocation-service/src/main/kotlin/com/baro/relocation/entity/StandWeight.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/entity/StandWeight.kt
@@ -22,6 +22,12 @@ data class StandWeight(
     @Column(name = "weight", nullable = false)
     val weight: Double,
 
+    @Column(name = "latitude", nullable = false)
+    val latitude: Double,
+
+    @Column(name = "longitude", nullable = false)
+    val longitude: Double,
+
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime = LocalDateTime.now()
 

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
@@ -23,8 +23,8 @@ class RelocationService(
                 timeZone = dto.timeZone,
                 dayOfWeek = dto.dayOfWeek,
                 weight = dto.weight,
-                longitude = dto.lon,
-                latitude = dto.lat,
+                longitude = dto.longitude,
+                latitude = dto.latitude,
                 updatedAt = LocalDateTime.now(),
             )
         }

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
@@ -23,7 +23,9 @@ class RelocationService(
                 timeZone = dto.timeZone,
                 dayOfWeek = dto.dayOfWeek,
                 weight = dto.weight,
-                updatedAt = LocalDateTime.now()
+                longitude = dto.lon,
+                latitude = dto.lat,
+                updatedAt = LocalDateTime.now(),
             )
         }
 


### PR DESCRIPTION
## Summary
- 가중치 데이터 저장 시 정류장의 위도, 경도 함께 받아서 저장
