### PR TITLE
feat: 배차 차량 위치 스트림 추가

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ArrivedService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ArrivedService.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service
 class ArrivedService(
     private val dispatchRepository: DispatchRepository,
     private val controlPort: ControlPort,
+    private val vehicleLocationStreamService: VehicleLocationStreamService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -26,6 +27,7 @@ class ArrivedService(
         when (phase) {
             "to_pickup" -> {
                 log.info("픽업 도착 — 목적지 이동 명령 전송. vehicleId={}, dispatchId={}", vehicleId, dispatchId)
+                vehicleLocationStreamService.publishArrival(dispatchId, dispatch.carId, phase)
                 controlPort.sendDispatchCommand(
                     carId = dispatch.carId,
                     tripId = tripId,
@@ -37,6 +39,7 @@ class ArrivedService(
             }
             "to_dest" -> {
                 log.info("목적지 도착 — 운행 완료. vehicleId={}, dispatchId={}", vehicleId, dispatchId)
+                vehicleLocationStreamService.publishArrival(dispatchId, dispatch.carId, phase)
                 dispatchRepository.update(dispatch.complete())
             }
             else -> log.warn("알 수 없는 phase. vehicleId={}, tripId={}, phase={}", vehicleId, tripId, phase)

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CarStateService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CarStateService.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service
 @Service
 open class CarStateService(
     private val dispatchableCarProjection: DispatchableCarProjection,
+    private val vehicleLocationStreamService: VehicleLocationStreamService,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -25,6 +26,8 @@ open class CarStateService(
                 dispatchableCarProjection.removeCar(command.carId)
             }
         }
+
+        vehicleLocationStreamService.publish(command)
     }
 }
 

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/VehicleLocationStreamService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/VehicleLocationStreamService.kt
@@ -1,0 +1,145 @@
+package com.baro.dispatch.application.service
+
+import com.baro.dispatch.domain.repository.DispatchRepository
+import com.baro.dispatch.infrastructure.kafka.CarStatus
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.io.IOException
+import jakarta.annotation.PreDestroy
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@Service
+class VehicleLocationStreamService(
+    private val dispatchRepository: DispatchRepository,
+) {
+    private val emittersByDispatchId = ConcurrentHashMap<Long, MutableSet<SseEmitter>>()
+    private val latestEventsByCarId = ConcurrentHashMap<Long, VehicleLocationEvent>()
+    private val heartbeatExecutor = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "vehicle-location-sse-heartbeat").apply { isDaemon = true }
+    }
+
+    init {
+        heartbeatExecutor.scheduleAtFixedRate(::sendHeartbeat, HEARTBEAT_INTERVAL_SECONDS, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS)
+    }
+
+    fun subscribe(dispatchId: Long, carId: Long): SseEmitter {
+        val emitter = SseEmitter(STREAM_TIMEOUT_MILLIS)
+        val emitters = emittersByDispatchId.computeIfAbsent(dispatchId) { ConcurrentHashMap.newKeySet() }
+        emitters.add(emitter)
+        cleanupOnTerminate(dispatchId, emitter)
+        sendEvent(dispatchId, emitter, "connected", mapOf("dispatch_id" to dispatchId, "car_id" to carId))
+        latestEventsByCarId[carId]?.let { latestEvent ->
+            sendEvent(dispatchId, emitter, "vehicle-location", latestEvent.copy(dispatchId = dispatchId))
+        }
+        return emitter
+    }
+
+    fun publish(command: CarStateCommand) {
+        val dispatch = dispatchRepository.findActiveByCarId(command.carId) ?: return
+        val dispatchId = dispatch.id ?: return
+        val payload = VehicleLocationEvent.from(dispatchId, command)
+        latestEventsByCarId[command.carId] = payload
+        publish(dispatchId, payload)
+    }
+
+    fun publishArrival(dispatchId: Long, carId: Long, phase: String) {
+        val previous = latestEventsByCarId[carId] ?: return
+        publish(
+            dispatchId,
+            previous.copy(
+                dispatchId = dispatchId,
+                status = if (phase == "to_dest") "arrived_destination" else "arrived_pickup",
+                phase = phase,
+            ),
+        )
+        if (phase == "to_dest") {
+            latestEventsByCarId.remove(carId)
+        }
+    }
+
+    private fun publish(dispatchId: Long, payload: VehicleLocationEvent) {
+        emittersByDispatchId[dispatchId]?.toList()?.forEach { emitter ->
+            sendEvent(dispatchId, emitter, "vehicle-location", payload)
+        }
+    }
+
+    private fun sendHeartbeat() {
+        emittersByDispatchId.forEach { (dispatchId, emitters) ->
+            emitters.toList().forEach { emitter ->
+                sendEvent(dispatchId, emitter, "ping", emptyMap<String, String>())
+            }
+        }
+    }
+
+    private fun sendEvent(dispatchId: Long, emitter: SseEmitter, eventName: String, payload: Any) {
+        try {
+            emitter.send(SseEmitter.event().name(eventName).data(payload))
+        } catch (exception: IOException) {
+            completeWithError(dispatchId, emitter, exception)
+        } catch (exception: IllegalStateException) {
+            completeWithError(dispatchId, emitter, exception)
+        }
+    }
+
+    private fun completeWithError(dispatchId: Long, emitter: SseEmitter, exception: Throwable) {
+        removeEmitter(dispatchId, emitter)
+        try {
+            emitter.completeWithError(exception)
+        } catch (_: IllegalStateException) {
+            // already completed
+        }
+    }
+
+    private fun cleanupOnTerminate(dispatchId: Long, emitter: SseEmitter) {
+        val cleanup = { removeEmitter(dispatchId, emitter) }
+        emitter.onCompletion(cleanup)
+        emitter.onTimeout(cleanup)
+        emitter.onError { _: Throwable -> cleanup() }
+    }
+
+    private fun removeEmitter(dispatchId: Long, emitter: SseEmitter) {
+        emittersByDispatchId[dispatchId]?.remove(emitter)
+        if (emittersByDispatchId[dispatchId]?.isEmpty() == true) {
+            emittersByDispatchId.remove(dispatchId)
+        }
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        heartbeatExecutor.shutdownNow()
+    }
+
+    private companion object {
+        const val STREAM_TIMEOUT_MILLIS = 10 * 60 * 1000L
+        const val HEARTBEAT_INTERVAL_SECONDS = 25L
+    }
+}
+
+data class VehicleLocationEvent(
+    @JsonProperty("dispatch_id") val dispatchId: Long,
+    @JsonProperty("car_id") val carId: Long,
+    val latitude: Double,
+    val longitude: Double,
+    val speed: Int,
+    val heading: Double,
+    val status: String,
+    val timestamp: String,
+    val phase: String,
+) {
+    companion object {
+        fun from(dispatchId: Long, command: CarStateCommand): VehicleLocationEvent = VehicleLocationEvent(
+            dispatchId = dispatchId,
+            carId = command.carId,
+            latitude = command.latitude,
+            longitude = command.longitude,
+            speed = command.speed,
+            heading = command.heading,
+            status = command.status.value,
+            timestamp = command.timestamp,
+            phase = if (command.status == CarStatus.DRIVING) "to_dest" else "to_pickup",
+        )
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/VehicleLocationStreamService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/VehicleLocationStreamService.kt
@@ -27,8 +27,11 @@ class VehicleLocationStreamService(
 
     fun subscribe(dispatchId: Long, carId: Long): SseEmitter {
         val emitter = SseEmitter(STREAM_TIMEOUT_MILLIS)
-        val emitters = emittersByDispatchId.computeIfAbsent(dispatchId) { ConcurrentHashMap.newKeySet() }
-        emitters.add(emitter)
+        emittersByDispatchId.compute(dispatchId) { _, existingEmitters ->
+            val emitters = existingEmitters ?: ConcurrentHashMap.newKeySet()
+            emitters.add(emitter)
+            emitters
+        }
         cleanupOnTerminate(dispatchId, emitter)
         sendEvent(dispatchId, emitter, "connected", mapOf("dispatch_id" to dispatchId, "car_id" to carId))
         latestEventsByCarId[carId]?.let { latestEvent ->
@@ -75,12 +78,14 @@ class VehicleLocationStreamService(
     }
 
     private fun sendEvent(dispatchId: Long, emitter: SseEmitter, eventName: String, payload: Any) {
-        try {
-            emitter.send(SseEmitter.event().name(eventName).data(payload))
-        } catch (exception: IOException) {
-            completeWithError(dispatchId, emitter, exception)
-        } catch (exception: IllegalStateException) {
-            completeWithError(dispatchId, emitter, exception)
+        synchronized(emitter) {
+            try {
+                emitter.send(SseEmitter.event().name(eventName).data(payload))
+            } catch (exception: IOException) {
+                completeWithError(dispatchId, emitter, exception)
+            } catch (exception: IllegalStateException) {
+                completeWithError(dispatchId, emitter, exception)
+            }
         }
     }
 
@@ -101,9 +106,9 @@ class VehicleLocationStreamService(
     }
 
     private fun removeEmitter(dispatchId: Long, emitter: SseEmitter) {
-        emittersByDispatchId[dispatchId]?.remove(emitter)
-        if (emittersByDispatchId[dispatchId]?.isEmpty() == true) {
-            emittersByDispatchId.remove(dispatchId)
+        emittersByDispatchId.computeIfPresent(dispatchId) { _, emitters ->
+            emitters.remove(emitter)
+            if (emitters.isEmpty()) null else emitters
         }
     }
 

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/VehicleLocationStreamController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/VehicleLocationStreamController.kt
@@ -1,0 +1,39 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.dispatch.application.service.VehicleLocationStreamService
+import com.baro.dispatch.domain.repository.DispatchRepository
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+@RestController
+@RequestMapping(DispatchApiPaths.DISPATCH)
+class VehicleLocationStreamController(
+    private val dispatchRepository: DispatchRepository,
+    private val vehicleLocationStreamService: VehicleLocationStreamService,
+) {
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/{dispatchId}/vehicle-location/stream", produces = ["text/event-stream"])
+    fun stream(
+        @PathVariable dispatchId: Long,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): SseEmitter {
+        val authenticatedUserId = jwt.subject?.toLongOrNull()
+            ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 사용자 정보가 올바르지 않습니다.")
+        val dispatch = dispatchRepository.findById(dispatchId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "배차를 찾을 수 없습니다.")
+
+        if (dispatch.userId != authenticatedUserId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "배차 위치 스트림 접근 권한이 없습니다.")
+        }
+
+        return vehicleLocationStreamService.subscribe(dispatchId, dispatch.carId)
+    }
+}

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
@@ -2,6 +2,8 @@ package com.baro.dispatch.application.service
 
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
 import com.baro.dispatch.application.port.out.DispatchableCarCandidate
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.repository.DispatchRepository
 import com.baro.dispatch.infrastructure.kafka.CarStatus
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,7 +23,7 @@ class CarStateServiceTest {
             }
 
             override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
-        })
+        }, noopVehicleLocationStreamService())
 
         service.handle(
             CarStateCommand(
@@ -53,7 +55,7 @@ class CarStateServiceTest {
             }
 
             override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
-        })
+        }, noopVehicleLocationStreamService())
 
         service.handle(
             CarStateCommand(
@@ -85,7 +87,7 @@ class CarStateServiceTest {
             }
 
             override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
-        })
+        }, noopVehicleLocationStreamService())
 
         service.handle(
             CarStateCommand(
@@ -103,4 +105,11 @@ class CarStateServiceTest {
 
         assertEquals(listOf("save:11:37.1:127.2"), calls)
     }
+
+    private fun noopVehicleLocationStreamService() = VehicleLocationStreamService(object : DispatchRepository {
+        override fun save(dispatch: Dispatch): Long = 0L
+        override fun update(dispatch: Dispatch) = Unit
+        override fun findById(dispatchId: Long): Dispatch? = null
+        override fun findActiveByCarId(carId: Long): Dispatch? = null
+    })
 }

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
@@ -4,6 +4,9 @@ import com.baro.dispatch.application.port.out.DispatchableCarProjection
 import com.baro.dispatch.application.port.out.DispatchableCarCandidate
 import com.baro.dispatch.application.service.CarStateCommand
 import com.baro.dispatch.application.service.CarStateService
+import com.baro.dispatch.application.service.VehicleLocationStreamService
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.repository.DispatchRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -17,7 +20,7 @@ class CarStateConsumerTest {
                 override fun saveIdleCarLocation(carId: Long, latitude: Double, longitude: Double) = Unit
                 override fun removeCar(carId: Long) = Unit
                 override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
-            }) {
+            }, noopVehicleLocationStreamService()) {
                 override fun handle(command: CarStateCommand) {
                     received = command
                 }
@@ -62,7 +65,7 @@ class CarStateConsumerTest {
                 override fun saveIdleCarLocation(carId: Long, latitude: Double, longitude: Double) = Unit
                 override fun removeCar(carId: Long) = Unit
                 override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
-            }) {
+            }, noopVehicleLocationStreamService()) {
                 override fun handle(command: CarStateCommand) {
                     received = command
                 }
@@ -85,4 +88,11 @@ class CarStateConsumerTest {
 
         assertEquals(CarStatus.MOVING_TO_PICKUP, received?.status)
     }
+
+    private fun noopVehicleLocationStreamService() = VehicleLocationStreamService(object : DispatchRepository {
+        override fun save(dispatch: Dispatch): Long = 0L
+        override fun update(dispatch: Dispatch) = Unit
+        override fun findById(dispatchId: Long): Dispatch? = null
+        override fun findActiveByCarId(carId: Long): Dispatch? = null
+    })
 }


### PR DESCRIPTION
## 요약
- 배차 단위 차량 위치 SSE 스트림 endpoint를 추가했습니다.
- Kafka 차량 상태 수신 시 active dispatch의 차량 위치를 해당 배차 stream으로 전달합니다.
- stream 접근 시 JWT 사용자와 배차 소유자를 검증합니다.
- SSE heartbeat, 초기 최신 위치 전송, 도착 이벤트 전달을 추가했습니다.

## 검증
- ./gradlew :dispatch-service:test