### PR TITLE
fix: 만료된 배차 가능 차량 정리

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CarStateService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CarStateService.kt
@@ -32,6 +32,7 @@ open class CarStateService(
 }
 
 data class CarStateCommand(
+    val carIdKey: String?,
     val carId: Long,
     val carNumber: String?,
     val latitude: Double,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumer.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumer.kt
@@ -4,6 +4,8 @@ import com.baro.dispatch.application.service.CarStateCommand
 import com.baro.dispatch.application.service.CarStateService
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
 
 @Component
@@ -18,16 +20,20 @@ class CarStateConsumer(
         containerFactory = "carStateKafkaListenerContainerFactory",
         autoStartup = "\${kafka.listener.car-state.auto-startup:true}",
     )
-    fun consume(message: CarStateMessage) {
-        log.info("차량 상태 메시지를 수신했습니다. carId={}, status={}", message.carId, message.status.value)
+    fun consume(
+        message: CarStateMessage,
+        @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) carIdKey: String?,
+    ) {
+        log.info("차량 상태 메시지를 수신했습니다. carId={}, key={}, status={}", message.carId, carIdKey, message.status.value)
         try {
-            carStateService.handle(message.toCommand())
+            carStateService.handle(message.toCommand(carIdKey))
         } catch (exception: Exception) {
             log.warn("차량 상태 메시지 처리에 실패했습니다. carId={}", message.carId, exception)
         }
     }
 
-    private fun CarStateMessage.toCommand() = CarStateCommand(
+    private fun CarStateMessage.toCommand(carIdKey: String?) = CarStateCommand(
+        carIdKey = carIdKey,
         carId = carId,
         carNumber = carNumber,
         latitude = latitude,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/DispatchRedisProperties.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/DispatchRedisProperties.kt
@@ -7,5 +7,5 @@ data class DispatchRedisProperties(
     val idleCarGeoKey: String = "dispatch:cars:idle:geo",
     val idleCarSearchRadiusKm: Double = 5.0,
     val idleCarMaxCandidates: Int = 10,
-    val stalenessThresholdSeconds: Long = 30L,
+    val stalenessThresholdSeconds: Long = 60L,
 )

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
@@ -45,8 +45,7 @@ class RedisDispatchableCarProjection(
 
     override fun removeCar(carId: Long) {
         log.info("Redis GEO에서 배차 가능 차량을 제거합니다. carId={}, key={}", carId, properties.idleCarGeoKey)
-        redisTemplate.opsForGeo().remove(properties.idleCarGeoKey, carId.toString())
-        redisTemplate.delete(listOf(carMetaKey(carId), carNumberKey(carId)))
+        removeCarsFromProjection(listOf(carId))
     }
 
     override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? {
@@ -71,6 +70,7 @@ class RedisDispatchableCarProjection(
             .multiGet(carIds.map { carMetaKey(it) }) ?: emptyList()
         val carNumberValues = redisTemplate.opsForValue()
             .multiGet(carIds.map { carNumberKey(it) }) ?: emptyList()
+        val staleCarIds = mutableListOf<Long>()
 
         for ((index, result) in results.withIndex()) {
             val carId = carIds[index]
@@ -78,12 +78,14 @@ class RedisDispatchableCarProjection(
 
             if (lastSeenMs == null || now - lastSeenMs > thresholdMs) {
                 log.warn("stale 차량 제외: carId={}, lastSeen={}ms 전", carId, lastSeenMs?.let { now - it } ?: "없음")
+                staleCarIds += carId
                 continue
             }
 
             val point = result.content.point
                 ?: throw IllegalStateException("Redis GEO 검색 결과에 좌표가 없습니다. carId=${result.content.name}")
 
+            removeStaleCars(staleCarIds)
             return DispatchableCarCandidate(
                 carId = carId,
                 carNumber = carNumberValues.getOrNull(index),
@@ -93,7 +95,26 @@ class RedisDispatchableCarProjection(
             )
         }
 
+        removeStaleCars(staleCarIds)
+
         log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", properties.idleCarSearchRadiusKm)
         return null
+    }
+
+    private fun removeStaleCars(carIds: List<Long>) {
+        if (carIds.isEmpty()) return
+
+        log.info("stale 배차 가능 차량을 Redis GEO에서 정리합니다. carIds={}", carIds)
+        removeCarsFromProjection(carIds)
+    }
+
+    private fun removeCarsFromProjection(carIds: List<Long>) {
+        if (carIds.isEmpty()) return
+
+        redisTemplate.opsForGeo().remove(
+            properties.idleCarGeoKey,
+            *carIds.map { it.toString() }.toTypedArray(),
+        )
+        redisTemplate.delete(carIds.flatMap { listOf(carMetaKey(it), carNumberKey(it)) })
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
@@ -104,8 +104,12 @@ class RedisDispatchableCarProjection(
     private fun removeStaleCars(carIds: List<Long>) {
         if (carIds.isEmpty()) return
 
-        log.info("stale 배차 가능 차량을 Redis GEO에서 정리합니다. carIds={}", carIds)
-        removeCarsFromProjection(carIds)
+        try {
+            log.info("stale 배차 가능 차량을 Redis GEO에서 정리합니다. carIds={}", carIds)
+            removeCarsFromProjection(carIds)
+        } catch (exception: Exception) {
+            log.error("stale 차량 정리 중 오류가 발생했습니다. carIds={}", carIds, exception)
+        }
     }
 
     private fun removeCarsFromProjection(carIds: List<Long>) {

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
@@ -27,6 +27,7 @@ class CarStateServiceTest {
 
         service.handle(
             CarStateCommand(
+                carIdKey = null,
                 carId = 11L,
                 carNumber = "12가3456",
                 latitude = 37.1,
@@ -59,6 +60,7 @@ class CarStateServiceTest {
 
         service.handle(
             CarStateCommand(
+                carIdKey = null,
                 carId = 11L,
                 carNumber = "12가3456",
                 latitude = 37.1,
@@ -91,6 +93,7 @@ class CarStateServiceTest {
 
         service.handle(
             CarStateCommand(
+                carIdKey = null,
                 carId = 11L,
                 carNumber = "12가3456",
                 latitude = 37.1,

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
@@ -39,10 +39,12 @@ class CarStateConsumerTest {
                 status = CarStatus.IDLE,
                 timestamp = "2026-06-04T10:00:00Z",
             ),
+            carIdKey = "101",
         )
 
         assertEquals(
             CarStateCommand(
+                carIdKey = "101",
                 carId = 101L,
                 carNumber = "12가3456",
                 latitude = 37.5,
@@ -83,6 +85,7 @@ class CarStateConsumerTest {
                 status = CarStatus.MOVING_TO_PICKUP,
                 timestamp = "2026-06-04T10:00:00Z",
             ),
+            carIdKey = "101",
         )
 
         assertEquals(CarStatus.MOVING_TO_PICKUP, received?.status)


### PR DESCRIPTION
## 변경 사항
- 배차 가능 차량 Redis projection 만료 기준 정리
- 차량 상태 Kafka 메시지 key를 command로 전달하고 로그에 포함
- 관련 dispatch-service 테스트 보강

## 검증
- ./gradlew :dispatch-service:test