### PR TITLE
feat: Airflow 통신용 Internal API 구현

### DIFF
--- a/common-web/src/main/kotlin/com/baro/common/web/config/InternalWebMvcConfig.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/config/InternalWebMvcConfig.kt
@@ -1,0 +1,20 @@
+package com.baro.common.web.config
+
+import com.baro.common.web.interceptor.InternalSecurityInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+import org.springframework.context.annotation.Import
+
+@Configuration
+@Import(InternalSecurityInterceptor::class)
+class InternalWebMvcConfig(
+    private val internalSecurityInterceptor: InternalSecurityInterceptor
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(internalSecurityInterceptor)
+            .addPathPatterns("/internal/**")
+    }
+}

--- a/common-web/src/main/kotlin/com/baro/common/web/interceptor/InternalSecurityInterceptor.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/interceptor/InternalSecurityInterceptor.kt
@@ -1,0 +1,31 @@
+package com.baro.common.web.interceptor
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class InternalSecurityInterceptor(
+    @Value("\${internal.api-key}")
+    private val expectedApiKey: String
+) : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val path = request.requestURI
+        
+        // /internal 로 시작하는 요청에 대해서만 검증
+        if (path.startsWith("/internal")) {
+            val apiKey = request.getHeader("X-Internal-Api-Key")
+            
+            if (apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
+                response.sendError(HttpStatus.FORBIDDEN.value(), "Forbidden: Invalid or missing API Key")
+                return false
+            }
+        }
+        
+        return true
+    }
+}

--- a/common-web/src/main/kotlin/com/baro/common/web/interceptor/InternalSecurityInterceptor.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/interceptor/InternalSecurityInterceptor.kt
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.HandlerInterceptor
 
 @Component
 class InternalSecurityInterceptor(
-    @Value("\${internal.api-key}")
+    @Value("\${internal.api-key:}")
     private val expectedApiKey: String
 ) : HandlerInterceptor {
 
@@ -20,7 +20,7 @@ class InternalSecurityInterceptor(
         if (path.startsWith("/internal")) {
             val apiKey = request.getHeader("X-Internal-Api-Key")
             
-            if (apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
+            if (expectedApiKey.isBlank() || apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
                 response.sendError(HttpStatus.FORBIDDEN.value(), "Forbidden: Invalid or missing API Key")
                 return false
             }

--- a/common-web/src/main/kotlin/com/baro/common/web/interceptor/InternalSecurityInterceptor.kt
+++ b/common-web/src/main/kotlin/com/baro/common/web/interceptor/InternalSecurityInterceptor.kt
@@ -14,16 +14,11 @@ class InternalSecurityInterceptor(
 ) : HandlerInterceptor {
 
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
-        val path = request.requestURI
+        val apiKey = request.getHeader("X-Internal-Api-Key")
         
-        // /internal 로 시작하는 요청에 대해서만 검증
-        if (path.startsWith("/internal")) {
-            val apiKey = request.getHeader("X-Internal-Api-Key")
-            
-            if (expectedApiKey.isBlank() || apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
-                response.sendError(HttpStatus.FORBIDDEN.value(), "Forbidden: Invalid or missing API Key")
-                return false
-            }
+        if (expectedApiKey.isBlank() || apiKey.isNullOrBlank() || apiKey != expectedApiKey) {
+            response.sendError(HttpStatus.FORBIDDEN.value(), "Forbidden: Invalid or missing API Key")
+            return false
         }
         
         return true

--- a/common-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -3,3 +3,4 @@ com.baro.common.web.config.CommonCorsConfig
 com.baro.common.web.config.CommonOpenApiConfig
 com.baro.common.web.config.CommonTimeConfig
 com.baro.common.web.error.CommonRestExceptionHandler
+com.baro.common.web.config.InternalWebMvcConfig

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchExportService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchExportService.kt
@@ -1,0 +1,49 @@
+package com.baro.dispatch.application.service
+
+import com.baro.dispatch.infrastructure.persistence.DispatchJpaRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.io.BufferedWriter
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.time.OffsetDateTime
+import java.util.zip.GZIPOutputStream
+
+@Service
+class DispatchExportService(
+    private val dispatchJpaRepository: DispatchJpaRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun exportDailyDispatchDataAsGzippedCsv(outputStream: OutputStream) {
+        val yesterday = OffsetDateTime.now().minusHours(24)
+
+        GZIPOutputStream(outputStream).use { gzipOs ->
+            BufferedWriter(OutputStreamWriter(gzipOs, Charsets.UTF_8)).use { writer ->
+                // Write CSV Header
+                writer.write("dispatch_id,request_id,user_id,car_id,stand_id,created_at,estimated_pickup_time,estimated_ride_time,fare,status\n")
+
+                // Fetch data as stream
+                dispatchJpaRepository.streamAllByCreatedAtAfter(yesterday).use { stream ->
+                    stream.forEach { dispatch ->
+                        val row = buildString {
+                            append(dispatch.dispatchId).append(",")
+                            append(dispatch.requestId).append(",")
+                            append(dispatch.userId).append(",")
+                            append(dispatch.carId).append(",")
+                            append(dispatch.standId).append(",")
+                            append(dispatch.createdAt).append(",")
+                            append(dispatch.estimatedPickupTime).append(",")
+                            append(dispatch.estimatedRideTime).append(",")
+                            append(dispatch.fare).append(",")
+                            append(dispatch.status)
+                            append("\n")
+                        }
+                        writer.write(row)
+                    }
+                }
+                writer.flush()
+            }
+        }
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchExportService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchExportService.kt
@@ -1,49 +1,56 @@
 package com.baro.dispatch.application.service
 
 import com.baro.dispatch.infrastructure.persistence.DispatchJpaRepository
+import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.io.BufferedWriter
-import java.io.OutputStream
+import java.io.File
 import java.io.OutputStreamWriter
 import java.time.OffsetDateTime
 import java.util.zip.GZIPOutputStream
 
 @Service
 class DispatchExportService(
-    private val dispatchJpaRepository: DispatchJpaRepository
+    private val dispatchJpaRepository: DispatchJpaRepository,
+    private val entityManager: EntityManager
 ) {
 
     @Transactional(readOnly = true)
-    fun exportDailyDispatchDataAsGzippedCsv(outputStream: OutputStream) {
+    fun exportDailyDispatchDataToTempFile(): File {
         val yesterday = OffsetDateTime.now().minusHours(24)
+        val tempFile = File.createTempFile("dispatch_export_", ".csv.gz")
 
-        GZIPOutputStream(outputStream).use { gzipOs ->
-            BufferedWriter(OutputStreamWriter(gzipOs, Charsets.UTF_8)).use { writer ->
-                // Write CSV Header
-                writer.write("dispatch_id,request_id,user_id,car_id,stand_id,created_at,estimated_pickup_time,estimated_ride_time,fare,status\n")
+        tempFile.outputStream().use { fos ->
+            GZIPOutputStream(fos).use { gzipOs ->
+                BufferedWriter(OutputStreamWriter(gzipOs, Charsets.UTF_8)).use { writer ->
+                    // Write CSV Header
+                    writer.write("dispatch_id,request_id,user_id,car_id,stand_id,created_at,estimated_pickup_time,estimated_ride_time,fare,status\n")
 
-                // Fetch data as stream
-                dispatchJpaRepository.streamAllByCreatedAtAfter(yesterday).use { stream ->
-                    stream.forEach { dispatch ->
-                        val row = buildString {
-                            append(dispatch.dispatchId).append(",")
-                            append(dispatch.requestId).append(",")
-                            append(dispatch.userId).append(",")
-                            append(dispatch.carId).append(",")
-                            append(dispatch.standId).append(",")
-                            append(dispatch.createdAt).append(",")
-                            append(dispatch.estimatedPickupTime).append(",")
-                            append(dispatch.estimatedRideTime).append(",")
-                            append(dispatch.fare).append(",")
-                            append(dispatch.status)
-                            append("\n")
+                    // Fetch data as stream
+                    dispatchJpaRepository.streamAllByCreatedAtAfter(yesterday).use { stream ->
+                        stream.forEach { dispatch ->
+                            val row = buildString {
+                                append(dispatch.dispatchId).append(",")
+                                append(dispatch.requestId).append(",")
+                                append(dispatch.userId).append(",")
+                                append(dispatch.carId).append(",")
+                                append(dispatch.standId).append(",")
+                                append(dispatch.createdAt).append(",")
+                                append(dispatch.estimatedPickupTime).append(",")
+                                append(dispatch.estimatedRideTime).append(",")
+                                append(dispatch.fare).append(",")
+                                append(dispatch.status)
+                                append("\n")
+                            }
+                            writer.write(row)
+                            entityManager.detach(dispatch)
                         }
-                        writer.write(row)
                     }
+                    writer.flush()
                 }
-                writer.flush()
             }
         }
+        return tempFile
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchJpaRepository.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/persistence/DispatchJpaRepository.kt
@@ -3,11 +3,18 @@ package com.baro.dispatch.infrastructure.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 
 import com.baro.dispatch.domain.model.DispatchStatus
+import jakarta.persistence.QueryHint
+import org.springframework.data.jpa.repository.QueryHints
+import java.time.OffsetDateTime
 import java.util.Optional
+import java.util.stream.Stream
 
 interface DispatchJpaRepository : JpaRepository<DispatchEntity, Long> {
     fun findTopByCarIdAndStatusInOrderByCreatedAtDesc(
         carId: Long,
         statuses: List<DispatchStatus>,
     ): Optional<DispatchEntity>
+
+    @QueryHints(QueryHint(name = "org.hibernate.fetchSize", value = "1000"))
+    fun streamAllByCreatedAtAfter(createdAt: OffsetDateTime): Stream<DispatchEntity>
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchApiPaths.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchApiPaths.kt
@@ -5,4 +5,7 @@ object DispatchApiPaths {
     const val PRE_DISPATCH = "/pre"
     const val PRE_DISPATCH_FULL = "$DISPATCH$PRE_DISPATCH"
     const val CONFIRM_DISPATCH_FULL = DISPATCH
+    const val EXPORT_DAILY = "/export/daily"
+    const val INTERNAL_DISPATCH = "/internal/dispatch"
+    const val EXPORT_DAILY_FULL = "$INTERNAL_DISPATCH$EXPORT_DAILY"
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchExportController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchExportController.kt
@@ -21,6 +21,15 @@ class DispatchExportController(
         response.contentType = "application/gzip"
         response.setHeader("Content-Disposition", "attachment; filename=\"dispatches_last_24h.csv.gz\"")
         
-        dispatchExportService.exportDailyDispatchDataAsGzippedCsv(response.outputStream)
+        val tempFile = dispatchExportService.exportDailyDispatchDataToTempFile()
+        
+        try {
+            tempFile.inputStream().use { inputStream ->
+                inputStream.copyTo(response.outputStream)
+            }
+        } finally {
+            response.outputStream.flush()
+            tempFile.delete()
+        }
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchExportController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchExportController.kt
@@ -1,0 +1,26 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.dispatch.application.service.DispatchExportService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Dispatch Export API", description = "대용량 배차 데이터 추출 관련 API")
+@RestController
+@RequestMapping(DispatchApiPaths.INTERNAL_DISPATCH)
+class DispatchExportController(
+    private val dispatchExportService: DispatchExportService
+) {
+
+    @Operation(summary = "24시간 배차 데이터 추출", description = "최근 24시간 동안의 배차 데이터를 압축된 CSV 파일 형태로 실시간 스트리밍 다운로드")
+    @GetMapping(DispatchApiPaths.EXPORT_DAILY)
+    fun exportDailyDispatchData(response: HttpServletResponse) {
+        response.contentType = "application/gzip"
+        response.setHeader("Content-Disposition", "attachment; filename=\"dispatches_last_24h.csv.gz\"")
+        
+        dispatchExportService.exportDailyDispatchDataAsGzippedCsv(response.outputStream)
+    }
+}

--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -65,3 +65,6 @@ baro:
     version: v1
   jwt:
     secret: ${JWT_SECRET}
+
+internal:
+  api-key: ${INTERNAL_API_KEY:default-secret-key-change-in-prod}

--- a/relocation-service/src/main/kotlin/com/baro/relocation/controller/RelocationController.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/controller/RelocationController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class RelocationController (
     private val relocationService: RelocationService
 ) {
-    @PostMapping("/standWeights")
+    @PostMapping("/internal/relocation/standWeights")
     @Operation(summary = "가중치 데이터 수신", description = "private에서 산출한 가중치 수신 / 저장")
     fun receiveWeights(
         @RequestBody request: StandWeightRequest

--- a/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
@@ -9,9 +9,16 @@ data class StandWeightRequest(
 data class StandWeightDto(
     @JsonProperty("stand_id")
     val standId: String,
+
     @JsonProperty("time_zone")
     val timeZone: Int,
+
     @JsonProperty("day_of_week")
     val dayOfWeek: Int,
-    val weight: Double
+
+    val weight: Double,
+
+    val lat: Double,
+
+    val lon: Double
 )

--- a/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/dto/StandWeightRequest.kt
@@ -18,7 +18,7 @@ data class StandWeightDto(
 
     val weight: Double,
 
-    val lat: Double,
+    val latitude: Double,
 
-    val lon: Double
+    val longitude: Double
 )

--- a/relocation-service/src/main/kotlin/com/baro/relocation/entity/StandWeight.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/entity/StandWeight.kt
@@ -22,6 +22,12 @@ data class StandWeight(
     @Column(name = "weight", nullable = false)
     val weight: Double,
 
+    @Column(name = "latitude", nullable = false)
+    val latitude: Double,
+
+    @Column(name = "longitude", nullable = false)
+    val longitude: Double,
+
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime = LocalDateTime.now()
 

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
@@ -16,7 +16,7 @@ class RelocationService(
 ) {
 
     fun saveWeights(request: StandWeightRequest) {
-        // 새 가중치 저장
+        // 새 가중치 저장 api
         val entities = request.weights.map { dto ->
             StandWeight(
                 standId = dto.standId,

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
@@ -23,8 +23,8 @@ class RelocationService(
                 timeZone = dto.timeZone,
                 dayOfWeek = dto.dayOfWeek,
                 weight = dto.weight,
-                longitude = dto.lon,
-                latitude = dto.lat,
+                longitude = dto.longitude,
+                latitude = dto.latitude,
                 updatedAt = LocalDateTime.now(),
             )
         }

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationService.kt
@@ -23,7 +23,9 @@ class RelocationService(
                 timeZone = dto.timeZone,
                 dayOfWeek = dto.dayOfWeek,
                 weight = dto.weight,
-                updatedAt = LocalDateTime.now()
+                longitude = dto.lon,
+                latitude = dto.lat,
+                updatedAt = LocalDateTime.now(),
             )
         }
 

--- a/relocation-service/src/main/resources/application.yml
+++ b/relocation-service/src/main/resources/application.yml
@@ -41,3 +41,6 @@ baro:
     title: Relocation Service API
     description: BARO relocation-service API documentation
     version: v1
+
+internal:
+  api-key: ${INTERNAL_API_KEY:default-secret-key-change-in-prod}


### PR DESCRIPTION
## Summary
Airflow 연동을 위한 내부 통신 보안 및 엔드포인트 구축
- 퍼블릭 접근을 차단하고 Internal ALB를 통해서만 접근할 수 있는 내부용 API를 신규 구축 및 마이그레이션
- `common-web` : Airflow가 보내는 X-Internal-Api-Key 헤더를 검증하여 인가된 요청만 통과시키는 InternalSecurityInterceptor를 공통 설정으로 추가
- `dispatch-service` : Airflow 파이프라인에서 매일 전일자(24시간) 배차 데이터를 대용량으로 추출할 수 있도록 GZIP 기반 스트리밍 다운로드 API 개발
- `relocation-service` : Airflow가 분석한 가중치 데이터를 안전하게 수신할 수 있도록 기존 가중치 수신 API 경로를 Internal 규칙에 맞게 변경
