### PR TITLE
feat: 배차 취소 API 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@
 - `interfaces.rest`: REST controller, REST DTO, REST 예외 핸들러를 둔다.
 - REST 예외 응답, Jackson snake_case, Clock, OpenAPI 기본 설정은 `common-web`을 우선 사용한다.
 
+## Kotlin 안정성 규칙
+
+- Kotlin non-null assertion(`!!`)은 사용하지 않는다.
+- nullable 값은 `?: throw ...`, `requireNotNull`, `checkNotNull`, 명시적 early return 등으로 의도를 드러내며 처리한다.
+- 플랫폼 타입이나 외부 라이브러리 반환값은 null 가능성을 가정하고 명시적으로 검증한다.
+- 트랜잭션 블록 안에는 DB 상태 변경만 두고, 외부 캐시/인메모리 저장소/HTTP 호출 같은 롤백 불가능한 작업은 커밋 성공 이후 수행한다.
+
 ## PRE배차 API
 
 - 엔드포인트: `POST /dispatch/pre`

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/port/out/ControlPort.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/port/out/ControlPort.kt
@@ -11,4 +11,9 @@ interface ControlPort {
         durationSeconds: Int,
         phase: String,
     )
+
+    fun sendCancelDispatchCommand(
+        carId: Long,
+        tripId: String,
+    )
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CancelDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CancelDispatchService.kt
@@ -1,0 +1,80 @@
+package com.baro.dispatch.application.service
+
+import com.baro.dispatch.application.port.out.ControlPort
+import com.baro.dispatch.application.port.out.DispatchableCarProjection
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.model.DispatchStatus
+import com.baro.dispatch.domain.repository.DispatchRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+
+@Service
+class CancelDispatchService(
+    private val dispatchRepository: DispatchRepository,
+    private val dispatchableCarProjection: DispatchableCarProjection,
+    private val controlPort: ControlPort,
+    private val pendingDispatchStore: PendingDispatchStore,
+    private val transactionTemplate: TransactionTemplate,
+) {
+    fun cancel(command: CancelDispatchCommand): CancelDispatchResult {
+        val dispatch = dispatchRepository.findById(command.dispatchId)
+            ?: throw IllegalArgumentException("배차 정보를 찾을 수 없습니다.")
+
+        require(dispatch.userId == command.userId) { "배차 요청 사용자와 취소 요청 사용자가 일치하지 않습니다." }
+        require(dispatch.status in CANCELLABLE_STATUSES) { "취소할 수 없는 배차 상태입니다." }
+
+        val cancelledDispatch = transactionTemplate.execute {
+            val cancelled = dispatch.cancel()
+            dispatchRepository.update(cancelled)
+            pendingDispatchStore.cancel(command.dispatchId)
+            restoreCarToDispatchableProjection(dispatch)
+            cancelled
+        }!!
+
+        controlPort.sendCancelDispatchCommand(
+            carId = cancelledDispatch.carId,
+            tripId = command.dispatchId.toString(),
+        )
+
+        return CancelDispatchResult(
+            dispatchId = requireNotNull(cancelledDispatch.id),
+            requestId = cancelledDispatch.requestId,
+            carId = cancelledDispatch.carId,
+            carNumber = cancelledDispatch.carNumber,
+            status = cancelledDispatch.status.name,
+        )
+    }
+
+    private fun restoreCarToDispatchableProjection(dispatch: Dispatch) {
+        val lastKnownPoint = dispatch.pickupRoutePath.firstOrNull() ?: return
+
+        dispatchableCarProjection.saveIdleCarLocation(
+            carId = dispatch.carId,
+            carNumber = dispatch.carNumber,
+            latitude = lastKnownPoint.latitude,
+            longitude = lastKnownPoint.longitude,
+        )
+    }
+
+    private companion object {
+        val CANCELLABLE_STATUSES = setOf(DispatchStatus.REQUESTED, DispatchStatus.ASSIGNED)
+    }
+}
+
+data class CancelDispatchCommand(
+    val dispatchId: Long,
+    val userId: Long,
+) {
+    init {
+        require(dispatchId > 0) { "배차 ID는 양수여야 합니다." }
+        require(userId > 0) { "사용자 ID는 양수여야 합니다." }
+    }
+}
+
+data class CancelDispatchResult(
+    val dispatchId: Long,
+    val requestId: Long,
+    val carId: Long,
+    val carNumber: String?,
+    val status: String,
+)

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CancelDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CancelDispatchService.kt
@@ -26,10 +26,11 @@ class CancelDispatchService(
         val cancelledDispatch = transactionTemplate.execute {
             val cancelled = dispatch.cancel()
             dispatchRepository.update(cancelled)
-            pendingDispatchStore.cancel(command.dispatchId)
-            restoreCarToDispatchableProjection(dispatch)
             cancelled
-        }!!
+        } ?: throw IllegalStateException("배차 취소 처리 중 오류가 발생했습니다.")
+
+        pendingDispatchStore.cancel(command.dispatchId)
+        restoreCarToDispatchableProjection(dispatch)
 
         controlPort.sendCancelDispatchCommand(
             carId = cancelledDispatch.carId,

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/PendingDispatch.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/PendingDispatch.kt
@@ -25,6 +25,10 @@ class PendingDispatchStore {
         store.remove(dispatchId)
     }
 
+    fun cancel(dispatchId: Long) {
+        store.remove(dispatchId)
+    }
+
     fun pollTimedOut(timeoutSeconds: Long): List<PendingDispatch> {
         val threshold = Instant.now().minusSeconds(timeoutSeconds)
         val timedOut = mutableListOf<PendingDispatch>()

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/control/ControlServiceClient.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/control/ControlServiceClient.kt
@@ -49,4 +49,22 @@ class ControlServiceClient(
             throw e
         }
     }
+
+    override fun sendCancelDispatchCommand(carId: Long, tripId: String) {
+        log.info("차량에 배차 취소 명령을 전송합니다. carId={}, tripId={}", carId, tripId)
+        val body = mapOf(
+            "type" to "CANCEL_DISPATCH",
+            "trip_id" to tripId,
+        )
+        try {
+            client.post()
+                .uri("/control/vehicles/$carId/command")
+                .body(body)
+                .retrieve()
+                .toBodilessEntity()
+        } catch (e: Exception) {
+            log.error("배차 취소 명령 전송 실패: carId={}, tripId={}, err={}", carId, tripId, e.message)
+            throw e
+        }
+    }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/CancelDispatchController.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/CancelDispatchController.kt
@@ -1,0 +1,46 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.common.web.response.BaseResponse
+import com.baro.dispatch.application.service.CancelDispatchCommand
+import com.baro.dispatch.application.service.CancelDispatchService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@RestController
+@RequestMapping(DispatchApiPaths.DISPATCH)
+class CancelDispatchController(
+    private val cancelDispatchService: CancelDispatchService,
+) {
+    @Operation(
+        summary = "배차 취소",
+        description = "차량이 출발지로 이동 중인 배차 요청을 취소합니다.",
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping(DispatchApiPaths.CANCEL_DISPATCH)
+    fun cancel(
+        @PathVariable dispatchId: Long,
+        @AuthenticationPrincipal jwt: Jwt,
+    ): BaseResponse<CancelDispatchResponse> {
+        val authenticatedUserId = jwt.subject?.toLongOrNull()
+            ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 사용자 정보가 올바르지 않습니다.")
+
+        return BaseResponse.success(
+            CancelDispatchResponse.from(
+                cancelDispatchService.cancel(
+                    CancelDispatchCommand(
+                        dispatchId = dispatchId,
+                        userId = authenticatedUserId,
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/CancelDispatchDtos.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/CancelDispatchDtos.kt
@@ -1,0 +1,34 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.dispatch.application.service.CancelDispatchResult
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CancelDispatchResponse(
+    @field:JsonProperty("dispatch_id")
+    @field:Schema(name = "dispatch_id", description = "배차 ID", example = "10")
+    val dispatchId: Long,
+    @field:JsonProperty("request_id")
+    @field:Schema(name = "request_id", description = "PRE배차 요청 ID", example = "1")
+    val requestId: Long,
+    @field:JsonProperty("car_id")
+    @field:Schema(name = "car_id", description = "차량 ID", example = "101")
+    val carId: Long,
+    @field:JsonProperty("car_number")
+    @field:Schema(name = "car_number", description = "차량번호", example = "12가3456")
+    val carNumber: String?,
+    @field:JsonProperty("dispatch_status")
+    @field:Schema(name = "dispatch_status", description = "배차 상태", example = "CANCELLED")
+    val dispatchStatus: String,
+) {
+    companion object {
+        fun from(result: CancelDispatchResult): CancelDispatchResponse =
+            CancelDispatchResponse(
+                dispatchId = result.dispatchId,
+                requestId = result.requestId,
+                carId = result.carId,
+                carNumber = result.carNumber,
+                dispatchStatus = result.status,
+            )
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchApiPaths.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/interfaces/rest/DispatchApiPaths.kt
@@ -5,6 +5,8 @@ object DispatchApiPaths {
     const val PRE_DISPATCH = "/pre"
     const val PRE_DISPATCH_FULL = "$DISPATCH$PRE_DISPATCH"
     const val CONFIRM_DISPATCH_FULL = DISPATCH
+    const val CANCEL_DISPATCH = "/{dispatchId}/cancel"
+    const val CANCEL_DISPATCH_FULL = "$DISPATCH$CANCEL_DISPATCH"
     const val EXPORT_DAILY = "/export/daily"
     const val INTERNAL_DISPATCH = "/internal/dispatch"
     const val EXPORT_DAILY_FULL = "$INTERNAL_DISPATCH$EXPORT_DAILY"

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CancelDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CancelDispatchServiceTest.kt
@@ -1,0 +1,128 @@
+package com.baro.dispatch.application.service
+
+import com.baro.dispatch.application.port.out.ControlPort
+import com.baro.dispatch.application.port.out.DispatchableCarCandidate
+import com.baro.dispatch.application.port.out.DispatchableCarProjection
+import com.baro.dispatch.domain.model.Dispatch
+import com.baro.dispatch.domain.model.DispatchStatus
+import com.baro.dispatch.domain.model.GeoPoint
+import com.baro.dispatch.domain.repository.DispatchRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.OffsetDateTime
+
+class CancelDispatchServiceTest {
+    @Test
+    fun `출발지로 이동 중인 배차를 취소한다`() {
+        var updatedDispatch: Dispatch? = null
+        val restoredCars = mutableListOf<RestoredCar>()
+        val cancelCommands = mutableListOf<Pair<Long, String>>()
+        val dispatch = dispatch(status = DispatchStatus.REQUESTED)
+        val service = cancelDispatchService(
+            dispatch = dispatch,
+            onUpdate = { updatedDispatch = it },
+            restoredCars = restoredCars,
+            cancelCommands = cancelCommands,
+        )
+
+        val result = service.cancel(CancelDispatchCommand(dispatchId = 10L, userId = 2L))
+
+        assertEquals(10L, result.dispatchId)
+        assertEquals(1L, result.requestId)
+        assertEquals(101L, result.carId)
+        assertEquals("12가3456", result.carNumber)
+        assertEquals("CANCELLED", result.status)
+        assertEquals(DispatchStatus.CANCELLED, updatedDispatch?.status)
+        assertEquals(listOf(RestoredCar(101L, "12가3456", 37.4, 127.1)), restoredCars)
+        assertEquals(listOf(101L to "10"), cancelCommands)
+    }
+
+    @Test
+    fun `배차 사용자가 아니면 취소할 수 없다`() {
+        val service = cancelDispatchService(dispatch = dispatch(status = DispatchStatus.REQUESTED))
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.cancel(CancelDispatchCommand(dispatchId = 10L, userId = 3L))
+        }
+
+        assertEquals("배차 요청 사용자와 취소 요청 사용자가 일치하지 않습니다.", exception.message)
+    }
+
+    @Test
+    fun `완료된 배차는 취소할 수 없다`() {
+        val service = cancelDispatchService(dispatch = dispatch(status = DispatchStatus.COMPLETED))
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            service.cancel(CancelDispatchCommand(dispatchId = 10L, userId = 2L))
+        }
+
+        assertEquals("취소할 수 없는 배차 상태입니다.", exception.message)
+    }
+
+    private fun cancelDispatchService(
+        dispatch: Dispatch?,
+        onUpdate: (Dispatch) -> Unit = {},
+        restoredCars: MutableList<RestoredCar> = mutableListOf(),
+        cancelCommands: MutableList<Pair<Long, String>> = mutableListOf(),
+    ): CancelDispatchService = CancelDispatchService(
+        dispatchRepository = object : DispatchRepository {
+            override fun save(dispatch: Dispatch): Long = error("사용하지 않습니다.")
+            override fun update(dispatch: Dispatch) = onUpdate(dispatch)
+            override fun findById(dispatchId: Long): Dispatch? = dispatch?.takeIf { dispatchId == it.id }
+            override fun findActiveByCarId(carId: Long): Dispatch? = null
+        },
+        dispatchableCarProjection = object : DispatchableCarProjection {
+            override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) {
+                restoredCars += RestoredCar(carId, carNumber, latitude, longitude)
+            }
+            override fun removeCar(carId: Long) = Unit
+            override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+        },
+        controlPort = object : ControlPort {
+            override fun sendDispatchCommand(
+                carId: Long,
+                tripId: String,
+                route: List<GeoPoint>,
+                distanceMeters: Int,
+                durationSeconds: Int,
+                phase: String,
+            ) = Unit
+            override fun sendCancelDispatchCommand(carId: Long, tripId: String) {
+                cancelCommands += carId to tripId
+            }
+        },
+        pendingDispatchStore = PendingDispatchStore(),
+        transactionTemplate = TransactionTemplate(object : PlatformTransactionManager {
+            override fun getTransaction(definition: org.springframework.transaction.TransactionDefinition?) =
+                org.springframework.transaction.support.SimpleTransactionStatus()
+            override fun commit(status: org.springframework.transaction.TransactionStatus) = Unit
+            override fun rollback(status: org.springframework.transaction.TransactionStatus) = Unit
+        }),
+    )
+
+    private fun dispatch(status: DispatchStatus): Dispatch = Dispatch(
+        id = 10L,
+        requestId = 1L,
+        userId = 2L,
+        carId = 101L,
+        carNumber = "12가3456",
+        standId = 0L,
+        createdAt = OffsetDateTime.parse("2026-04-27T00:00:00Z"),
+        estimatedPickupTime = 5,
+        estimatedRideTime = 20,
+        pickupRoutePath = listOf(GeoPoint(longitude = 127.1, latitude = 37.4)),
+        dropoffRoutePath = emptyList(),
+        fare = 12_100,
+        status = status,
+    )
+
+    data class RestoredCar(
+        val carId: Long,
+        val carNumber: String?,
+        val latitude: Double,
+        val longitude: Double,
+    )
+}

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
@@ -272,5 +272,6 @@ class ConfirmDispatchServiceTest {
             carId: Long, tripId: String, route: List<GeoPoint>,
             distanceMeters: Int, durationSeconds: Int, phase: String,
         ) = Unit
+        override fun sendCancelDispatchCommand(carId: Long, tripId: String) = Unit
     }
 }

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/CancelDispatchControllerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/interfaces/rest/CancelDispatchControllerTest.kt
@@ -1,0 +1,76 @@
+package com.baro.dispatch.interfaces.rest
+
+import com.baro.common.web.config.CommonJacksonConfig
+import com.baro.common.web.error.CommonRestExceptionHandler
+import com.baro.dispatch.application.service.CancelDispatchCommand
+import com.baro.dispatch.application.service.CancelDispatchResult
+import com.baro.dispatch.application.service.CancelDispatchService
+import com.baro.dispatch.infrastructure.security.SecurityConfig
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.Instant
+
+@WebMvcTest(CancelDispatchController::class)
+@Import(CommonJacksonConfig::class, CommonRestExceptionHandler::class, DispatchRestExceptionHandler::class, SecurityConfig::class)
+class CancelDispatchControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var cancelDispatchService: CancelDispatchService
+
+    @MockBean
+    private lateinit var jwtDecoder: JwtDecoder
+
+    @Test
+    fun `인증된 배차 취소 요청 시 취소 결과를 반환한다`() {
+        given(jwtDecoder.decode("access-token")).willReturn(`인증 토큰`())
+        given(cancelDispatchService.cancel(CancelDispatchCommand(dispatchId = 10L, userId = 2L))).willReturn(
+            CancelDispatchResult(
+                dispatchId = 10L,
+                requestId = 1L,
+                carId = 101L,
+                carNumber = "12가3456",
+                status = "CANCELLED",
+            ),
+        )
+
+        mockMvc.post(DispatchApiPaths.CANCEL_DISPATCH_FULL, 10L) {
+            header("Authorization", "Bearer access-token")
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.dispatch_id") { value(10) }
+            jsonPath("$.data.request_id") { value(1) }
+            jsonPath("$.data.car_id") { value(101) }
+            jsonPath("$.data.car_number") { value("12가3456") }
+            jsonPath("$.data.dispatch_status") { value("CANCELLED") }
+        }
+    }
+
+    @Test
+    fun `배차 취소 요청 시 엑세스 토큰이 없으면 인증 오류를 반환한다`() {
+        mockMvc.post(DispatchApiPaths.CANCEL_DISPATCH_FULL, 10L)
+            .andExpect {
+                status { isUnauthorized() }
+                jsonPath("$.error.code") { value("UNAUTHORIZED") }
+            }
+    }
+
+    private fun `인증 토큰`(): Jwt =
+        Jwt.withTokenValue("access-token")
+            .header("alg", "HS256")
+            .subject("2")
+            .claim("email", "user@example.com")
+            .issuedAt(Instant.parse("2026-04-27T00:00:00Z"))
+            .expiresAt(Instant.parse("2026-04-27T00:15:00Z"))
+            .build()
+}


### PR DESCRIPTION
## Summary
- `POST /dispatch/{dispatchId}/cancel` 배차 취소 API 추가
- 배차 사용자 검증 및 REQUESTED/ASSIGNED 상태 취소 처리
- 취소 시 pending ACK store 제거 및 차량에 `CANCEL_DISPATCH` 명령 전송
- 배차 취소 서비스/컨트롤러 테스트 추가

## Test
- ./gradlew :dispatch-service:test