### PR TITLE
feat: 배차 차량 선점 처리 추가

### DIFF
--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/port/out/DispatchableCarProjection.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/port/out/DispatchableCarProjection.kt
@@ -3,7 +3,9 @@ package com.baro.dispatch.application.port.out
 interface DispatchableCarProjection {
     fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double)
     fun removeCar(carId: Long)
-    fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate?
+    fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate>
+    fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? =
+        findNearestIdleCars(latitude, longitude).firstOrNull()
 }
 
 data class DispatchableCarCandidate(

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/port/out/VehicleReservationPort.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/port/out/VehicleReservationPort.kt
@@ -1,0 +1,6 @@
+package com.baro.dispatch.application.port.out
+
+interface VehicleReservationPort {
+    fun reserve(carId: Long, ownerId: String): Boolean
+    fun release(carId: Long, ownerId: String)
+}

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CancelDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CancelDispatchService.kt
@@ -2,6 +2,7 @@ package com.baro.dispatch.application.service
 
 import com.baro.dispatch.application.port.out.ControlPort
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
+import com.baro.dispatch.application.port.out.VehicleReservationPort
 import com.baro.dispatch.domain.model.Dispatch
 import com.baro.dispatch.domain.model.DispatchStatus
 import com.baro.dispatch.domain.repository.DispatchRepository
@@ -12,6 +13,7 @@ import org.springframework.transaction.support.TransactionTemplate
 class CancelDispatchService(
     private val dispatchRepository: DispatchRepository,
     private val dispatchableCarProjection: DispatchableCarProjection,
+    private val vehicleReservationPort: VehicleReservationPort,
     private val controlPort: ControlPort,
     private val pendingDispatchStore: PendingDispatchStore,
     private val transactionTemplate: TransactionTemplate,
@@ -30,6 +32,7 @@ class CancelDispatchService(
         } ?: throw IllegalStateException("배차 취소 처리 중 오류가 발생했습니다.")
 
         pendingDispatchStore.cancel(command.dispatchId)
+        releaseReservations(dispatch)
         restoreCarToDispatchableProjection(dispatch)
 
         controlPort.sendCancelDispatchCommand(
@@ -55,6 +58,11 @@ class CancelDispatchService(
             latitude = lastKnownPoint.latitude,
             longitude = lastKnownPoint.longitude,
         )
+    }
+
+    private fun releaseReservations(dispatch: Dispatch) {
+        vehicleReservationPort.release(dispatch.carId, "dispatch-request:${dispatch.requestId}")
+        dispatch.id?.let { vehicleReservationPort.release(dispatch.carId, "dispatch-retry:$it") }
     }
 
     private companion object {

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ConfirmDispatchService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/ConfirmDispatchService.kt
@@ -3,7 +3,9 @@ package com.baro.dispatch.application.service
 import com.baro.dispatch.application.port.out.ControlPort
 import com.baro.dispatch.application.port.out.DirectionsPort
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
+import com.baro.dispatch.application.port.out.DispatchableCarCandidate
 import com.baro.dispatch.application.port.out.RouteEstimate
+import com.baro.dispatch.application.port.out.VehicleReservationPort
 import com.baro.dispatch.domain.model.Dispatch
 import com.baro.dispatch.domain.model.DispatchRequestStatus
 import com.baro.dispatch.domain.model.GeoPoint
@@ -21,6 +23,7 @@ class ConfirmDispatchService(
     private val dispatchRequestRepository: DispatchRequestRepository,
     private val dispatchRepository: DispatchRepository,
     private val dispatchableCarProjection: DispatchableCarProjection,
+    private val vehicleReservationPort: VehicleReservationPort,
     private val directionsPort: DirectionsPort,
     private val controlPort: ControlPort,
     private val pendingDispatchStore: PendingDispatchStore,
@@ -36,35 +39,39 @@ class ConfirmDispatchService(
         require(preDispatchRequest.status == DispatchRequestStatus.PENDING) { "이미 처리된 PRE배차 요청입니다." }
         require(!preDispatchRequest.isExpired(now)) { "만료된 PRE배차 요청입니다." }
 
-        val dispatchableCar = dispatchableCarProjection.findNearestIdleCar(
+        val dispatchableCar = reserveNearestIdleCar(
             latitude = preDispatchRequest.origin.latitude,
             longitude = preDispatchRequest.origin.longitude,
+            ownerId = reservationOwnerId(command.requestId),
         ) ?: throw IllegalArgumentException("배차 가능한 차량을 찾을 수 없습니다.")
 
-        // 트랜잭션 외부에서 외부 API 호출 (커넥션 점유 최소화)
-        val carLocation = GeoPoint(latitude = dispatchableCar.latitude, longitude = dispatchableCar.longitude)
-        val pickupRoute = directionsPort.findRoute(carLocation, preDispatchRequest.origin)
+        val ownerId = reservationOwnerId(command.requestId)
+        val pickupRoute = try {
+            // 트랜잭션 외부에서 외부 API 호출 (커넥션 점유 최소화)
+            val carLocation = GeoPoint(latitude = dispatchableCar.latitude, longitude = dispatchableCar.longitude)
+            directionsPort.findRoute(carLocation, preDispatchRequest.origin)
+        } catch (exception: Exception) {
+            vehicleReservationPort.release(dispatchableCar.carId, ownerId)
+            throw exception
+        }
         val estimatedPickupTime = ceil(pickupRoute.durationSeconds / SECONDS_PER_MINUTE).toInt()
 
-        val dispatchId = saveDispatch(
-            command = command,
-            now = now,
-            carId = dispatchableCar.carId,
-            carNumber = dispatchableCar.carNumber,
-            estimatedPickupTime = estimatedPickupTime,
-            pickupRoute = pickupRoute,
-            preDispatchRequest = preDispatchRequest,
-        )
+        val dispatchId = try {
+            saveDispatch(
+                command = command,
+                now = now,
+                carId = dispatchableCar.carId,
+                carNumber = dispatchableCar.carNumber,
+                estimatedPickupTime = estimatedPickupTime,
+                pickupRoute = pickupRoute,
+                preDispatchRequest = preDispatchRequest,
+            )
+        } catch (exception: Exception) {
+            vehicleReservationPort.release(dispatchableCar.carId, ownerId)
+            throw exception
+        }
 
-        // DB 커밋 후 외부 명령 전송 (롤백 시 명령 전송 방지)
-        controlPort.sendDispatchCommand(
-            carId = dispatchableCar.carId,
-            tripId = dispatchId.toString(),
-            route = pickupRoute.routePath,
-            distanceMeters = pickupRoute.distanceMeters,
-            durationSeconds = pickupRoute.durationSeconds,
-            phase = "to_pickup",
-        )
+        dispatchableCarProjection.removeCar(dispatchableCar.carId)
 
         pendingDispatchStore.register(
             PendingDispatch(
@@ -74,6 +81,16 @@ class ConfirmDispatchService(
                 originLatitude = preDispatchRequest.origin.latitude,
                 originLongitude = preDispatchRequest.origin.longitude,
             )
+        )
+
+        // DB 커밋 및 pending 등록 후 외부 명령 전송 (빠른 ACK 유실 방지)
+        controlPort.sendDispatchCommand(
+            carId = dispatchableCar.carId,
+            tripId = dispatchId.toString(),
+            route = pickupRoute.routePath,
+            distanceMeters = pickupRoute.distanceMeters,
+            durationSeconds = pickupRoute.durationSeconds,
+            phase = "to_pickup",
         )
 
         return ConfirmDispatchResult(
@@ -109,8 +126,6 @@ class ConfirmDispatchService(
         pickupRoute: RouteEstimate,
         preDispatchRequest: com.baro.dispatch.domain.model.DispatchRequest,
     ): Long = transactionTemplate.execute {
-        dispatchableCarProjection.removeCar(carId)
-
         val dispatch = Dispatch.requested(
             requestId = command.requestId,
             userId = command.userId,
@@ -129,10 +144,16 @@ class ConfirmDispatchService(
         dispatchId
     }!!
 
+    private fun reserveNearestIdleCar(latitude: Double, longitude: Double, ownerId: String): DispatchableCarCandidate? =
+        dispatchableCarProjection.findNearestIdleCars(latitude, longitude)
+            .firstOrNull { candidate -> vehicleReservationPort.reserve(candidate.carId, ownerId) }
+
     private companion object {
         const val TEMPORARY_STAND_ID = 0L
         const val SECONDS_PER_MINUTE = 60.0
         val PRE_DISPATCH_EXPIRATION: Duration = Duration.ofMinutes(10)
+
+        fun reservationOwnerId(requestId: Long): String = "dispatch-request:$requestId"
 
         fun com.baro.dispatch.domain.model.DispatchRequest.isExpired(now: OffsetDateTime): Boolean =
             requestedAt.plus(PRE_DISPATCH_EXPIRATION).isBefore(now)

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchRetryService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchRetryService.kt
@@ -96,6 +96,8 @@ class DispatchRetryService(
             throw e
         }
 
+        releasePreviousReservations(pending)
+
         pendingStore.register(
             PendingDispatch(
                 dispatchId = pending.dispatchId,
@@ -121,5 +123,10 @@ class DispatchRetryService(
     private companion object {
         const val SECONDS_PER_MINUTE = 60.0
         fun reservationOwnerId(dispatchId: Long): String = "dispatch-retry:$dispatchId"
+    }
+
+    private fun releasePreviousReservations(pending: PendingDispatch) {
+        vehicleReservationPort.release(pending.carId, "dispatch-request:${pending.requestId}")
+        vehicleReservationPort.release(pending.carId, reservationOwnerId(pending.dispatchId))
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchRetryService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/DispatchRetryService.kt
@@ -3,6 +3,7 @@ package com.baro.dispatch.application.service
 import com.baro.dispatch.application.port.out.ControlPort
 import com.baro.dispatch.application.port.out.DirectionsPort
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
+import com.baro.dispatch.application.port.out.VehicleReservationPort
 import com.baro.dispatch.domain.model.GeoPoint
 import com.baro.dispatch.domain.repository.DispatchRepository
 import com.baro.dispatch.domain.repository.DispatchRequestRepository
@@ -18,6 +19,7 @@ class DispatchRetryService(
     private val dispatchRepository: DispatchRepository,
     private val dispatchRequestRepository: DispatchRequestRepository,
     private val dispatchableCarProjection: DispatchableCarProjection,
+    private val vehicleReservationPort: VehicleReservationPort,
     private val directionsPort: DirectionsPort,
     private val controlPort: ControlPort,
     @Value("\${dispatch.ack-timeout-seconds:10}") private val ackTimeoutSeconds: Long,
@@ -47,10 +49,11 @@ class DispatchRetryService(
             return
         }
 
-        val nextCar = dispatchableCarProjection.findNearestIdleCar(
+        val ownerId = reservationOwnerId(pending.dispatchId)
+        val nextCar = dispatchableCarProjection.findNearestIdleCars(
             latitude = pending.originLatitude,
             longitude = pending.originLongitude,
-        )
+        ).firstOrNull { candidate -> vehicleReservationPort.reserve(candidate.carId, ownerId) }
 
         if (nextCar == null) {
             log.warn("재배차 실패 — 가용 차량 없음: dispatchId={}", pending.dispatchId)
@@ -60,6 +63,7 @@ class DispatchRetryService(
 
         val request = dispatchRequestRepository.findById(pending.requestId)
         if (request == null) {
+            vehicleReservationPort.release(nextCar.carId, ownerId)
             log.warn("재배차 실패 — request 없음: requestId={}", pending.requestId)
             return
         }
@@ -70,6 +74,7 @@ class DispatchRetryService(
                 request.origin,
             )
         } catch (e: Exception) {
+            vehicleReservationPort.release(nextCar.carId, ownerId)
             log.error("재배차 경로 계산 실패: dispatchId={}, err={}", pending.dispatchId, e.message)
             dispatchRepository.update(dispatch.cancel())
             return
@@ -83,17 +88,13 @@ class DispatchRetryService(
             newEstimatedPickupTime = newEstimatedPickupTime,
         )
 
-        dispatchableCarProjection.removeCar(nextCar.carId)
-        dispatchRepository.update(reassigned)
-
-        controlPort.sendDispatchCommand(
-            carId = nextCar.carId,
-            tripId = pending.dispatchId.toString(),
-            route = pickupRoute.routePath,
-            distanceMeters = pickupRoute.distanceMeters,
-            durationSeconds = pickupRoute.durationSeconds,
-            phase = "to_pickup",
-        )
+        try {
+            dispatchRepository.update(reassigned)
+            dispatchableCarProjection.removeCar(nextCar.carId)
+        } catch (e: Exception) {
+            vehicleReservationPort.release(nextCar.carId, ownerId)
+            throw e
+        }
 
         pendingStore.register(
             PendingDispatch(
@@ -105,10 +106,20 @@ class DispatchRetryService(
             )
         )
 
+        controlPort.sendDispatchCommand(
+            carId = nextCar.carId,
+            tripId = pending.dispatchId.toString(),
+            route = pickupRoute.routePath,
+            distanceMeters = pickupRoute.distanceMeters,
+            durationSeconds = pickupRoute.durationSeconds,
+            phase = "to_pickup",
+        )
+
         log.info("재배차 완료: dispatchId={}, 이전carId={}, 새carId={}", pending.dispatchId, pending.carId, nextCar.carId)
     }
 
     private companion object {
         const val SECONDS_PER_MINUTE = 60.0
+        fun reservationOwnerId(dispatchId: Long): String = "dispatch-retry:$dispatchId"
     }
 }

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/DispatchRedisProperties.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/DispatchRedisProperties.kt
@@ -6,6 +6,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class DispatchRedisProperties(
     val idleCarGeoKey: String = "dispatch:cars:idle:geo",
     val idleCarSearchRadiusKm: Double = 5.0,
+    val idleCarSearchRadiiKm: List<Double> = emptyList(),
     val idleCarMaxCandidates: Int = 10,
     val stalenessThresholdSeconds: Long = 60L,
+    val reservationKeyPrefix: String = "dispatch:vehicle:reservation:",
+    val reservationTtlSeconds: Long = 30L,
 )

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
@@ -48,29 +48,46 @@ class RedisDispatchableCarProjection(
         removeCarsFromProjection(listOf(carId))
     }
 
-    override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? {
+    override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> {
+        val candidatesByCarId = linkedMapOf<Long, DispatchableCarCandidate>()
+
+        for (radiusKm in searchRadiiKm()) {
+            val candidates = findNearestIdleCars(latitude, longitude, radiusKm)
+            for (candidate in candidates) {
+                candidatesByCarId.putIfAbsent(candidate.carId, candidate)
+            }
+        }
+
+        if (candidatesByCarId.isEmpty()) {
+            log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", searchRadiiKm().last())
+        }
+        return candidatesByCarId.values.sortedBy { it.distanceKm ?: Double.MAX_VALUE }
+    }
+
+    private fun findNearestIdleCars(latitude: Double, longitude: Double, radiusKm: Double): List<DispatchableCarCandidate> {
         val results = redisTemplate.opsForGeo().search(
             properties.idleCarGeoKey,
             GeoReference.fromCoordinate(longitude, latitude),
-            Distance(properties.idleCarSearchRadiusKm, Metrics.KILOMETERS),
+            Distance(radiusKm, Metrics.KILOMETERS),
             RedisGeoCommands.GeoSearchCommandArgs.newGeoSearchArgs()
                 .includeDistance()
                 .includeCoordinates()
                 .sortAscending()
                 .limit(properties.idleCarMaxCandidates.toLong()),
-        ) ?: return null
+        ) ?: return emptyList()
 
         val thresholdMs = properties.stalenessThresholdSeconds * 1_000L
         val now = System.currentTimeMillis()
 
         val carIds = results.map { it.content.name.toLong() }
-        if (carIds.isEmpty()) return null
+        if (carIds.isEmpty()) return emptyList()
 
         val lastSeenValues = redisTemplate.opsForValue()
             .multiGet(carIds.map { carMetaKey(it) }) ?: emptyList()
         val carNumberValues = redisTemplate.opsForValue()
             .multiGet(carIds.map { carNumberKey(it) }) ?: emptyList()
         val staleCarIds = mutableListOf<Long>()
+        val candidates = mutableListOf<DispatchableCarCandidate>()
 
         for ((index, result) in results.withIndex()) {
             val carId = carIds[index]
@@ -85,8 +102,7 @@ class RedisDispatchableCarProjection(
             val point = result.content.point
                 ?: throw IllegalStateException("Redis GEO 검색 결과에 좌표가 없습니다. carId=${result.content.name}")
 
-            removeStaleCars(staleCarIds)
-            return DispatchableCarCandidate(
+            candidates += DispatchableCarCandidate(
                 carId = carId,
                 carNumber = carNumberValues.getOrNull(index),
                 distanceKm = result.distance.value,
@@ -97,9 +113,18 @@ class RedisDispatchableCarProjection(
 
         removeStaleCars(staleCarIds)
 
-        log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", properties.idleCarSearchRadiusKm)
-        return null
+        if (candidates.isEmpty()) {
+            log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", radiusKm)
+        }
+        return candidates
     }
+
+    private fun searchRadiiKm(): List<Double> =
+        properties.idleCarSearchRadiiKm
+            .filter { it > 0.0 }
+            .distinct()
+            .sorted()
+            .ifEmpty { listOf(properties.idleCarSearchRadiusKm) }
 
     private fun removeStaleCars(carIds: List<Long>) {
         if (carIds.isEmpty()) return

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
@@ -49,19 +49,13 @@ class RedisDispatchableCarProjection(
     }
 
     override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> {
-        val candidatesByCarId = linkedMapOf<Long, DispatchableCarCandidate>()
+        val maxRadiusKm = searchRadiiKm().last()
+        val candidates = findNearestIdleCars(latitude, longitude, maxRadiusKm)
 
-        for (radiusKm in searchRadiiKm()) {
-            val candidates = findNearestIdleCars(latitude, longitude, radiusKm)
-            for (candidate in candidates) {
-                candidatesByCarId.putIfAbsent(candidate.carId, candidate)
-            }
+        if (candidates.isEmpty()) {
+            log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", maxRadiusKm)
         }
-
-        if (candidatesByCarId.isEmpty()) {
-            log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", searchRadiiKm().last())
-        }
-        return candidatesByCarId.values.sortedBy { it.distanceKm ?: Double.MAX_VALUE }
+        return candidates
     }
 
     private fun findNearestIdleCars(latitude: Double, longitude: Double, radiusKm: Double): List<DispatchableCarCandidate> {

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisVehicleReservationAdapter.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisVehicleReservationAdapter.kt
@@ -1,0 +1,35 @@
+package com.baro.dispatch.infrastructure.redis
+
+import com.baro.dispatch.application.port.out.VehicleReservationPort
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RedisVehicleReservationAdapter(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val properties: DispatchRedisProperties,
+) : VehicleReservationPort {
+    override fun reserve(carId: Long, ownerId: String): Boolean =
+        redisTemplate.opsForValue()
+            .setIfAbsent(reservationKey(carId), ownerId, Duration.ofSeconds(properties.reservationTtlSeconds)) == true
+
+    override fun release(carId: Long, ownerId: String) {
+        redisTemplate.execute(RELEASE_SCRIPT, listOf(reservationKey(carId)), ownerId)
+    }
+
+    private fun reservationKey(carId: Long): String = "${properties.reservationKeyPrefix}$carId"
+
+    private companion object {
+        val RELEASE_SCRIPT = DefaultRedisScript(
+            """
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+              return redis.call('DEL', KEYS[1])
+            end
+            return 0
+            """.trimIndent(),
+            Long::class.java,
+        )
+    }
+}

--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -53,6 +53,7 @@ dispatch:
   redis:
     idle-car-geo-key: ${DISPATCH_REDIS_IDLE_CAR_GEO_KEY:dispatch:cars:idle:geo}
     idle-car-search-radius-km: ${DISPATCH_REDIS_IDLE_CAR_SEARCH_RADIUS_KM:5.0}
+    idle-car-search-radii-km: ${DISPATCH_REDIS_IDLE_CAR_SEARCH_RADII_KM:5.0,10.0,15.0}
 
 baro:
   error:

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CancelDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CancelDispatchServiceTest.kt
@@ -3,6 +3,7 @@ package com.baro.dispatch.application.service
 import com.baro.dispatch.application.port.out.ControlPort
 import com.baro.dispatch.application.port.out.DispatchableCarCandidate
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
+import com.baro.dispatch.application.port.out.VehicleReservationPort
 import com.baro.dispatch.domain.model.Dispatch
 import com.baro.dispatch.domain.model.DispatchStatus
 import com.baro.dispatch.domain.model.GeoPoint
@@ -20,12 +21,14 @@ class CancelDispatchServiceTest {
         var updatedDispatch: Dispatch? = null
         val restoredCars = mutableListOf<RestoredCar>()
         val cancelCommands = mutableListOf<Pair<Long, String>>()
+        val releasedReservations = mutableListOf<Pair<Long, String>>()
         val dispatch = dispatch(status = DispatchStatus.REQUESTED)
         val service = cancelDispatchService(
             dispatch = dispatch,
             onUpdate = { updatedDispatch = it },
             restoredCars = restoredCars,
             cancelCommands = cancelCommands,
+            releasedReservations = releasedReservations,
         )
 
         val result = service.cancel(CancelDispatchCommand(dispatchId = 10L, userId = 2L))
@@ -38,6 +41,10 @@ class CancelDispatchServiceTest {
         assertEquals(DispatchStatus.CANCELLED, updatedDispatch?.status)
         assertEquals(listOf(RestoredCar(101L, "12가3456", 37.4, 127.1)), restoredCars)
         assertEquals(listOf(101L to "10"), cancelCommands)
+        assertEquals(
+            listOf(101L to "dispatch-request:1", 101L to "dispatch-retry:10"),
+            releasedReservations,
+        )
     }
 
     @Test
@@ -67,6 +74,7 @@ class CancelDispatchServiceTest {
         onUpdate: (Dispatch) -> Unit = {},
         restoredCars: MutableList<RestoredCar> = mutableListOf(),
         cancelCommands: MutableList<Pair<Long, String>> = mutableListOf(),
+        releasedReservations: MutableList<Pair<Long, String>> = mutableListOf(),
     ): CancelDispatchService = CancelDispatchService(
         dispatchRepository = object : DispatchRepository {
             override fun save(dispatch: Dispatch): Long = error("사용하지 않습니다.")
@@ -79,7 +87,13 @@ class CancelDispatchServiceTest {
                 restoredCars += RestoredCar(carId, carNumber, latitude, longitude)
             }
             override fun removeCar(carId: Long) = Unit
-            override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+            override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
+        },
+        vehicleReservationPort = object : VehicleReservationPort {
+            override fun reserve(carId: Long, ownerId: String): Boolean = error("사용하지 않습니다.")
+            override fun release(carId: Long, ownerId: String) {
+                releasedReservations += carId to ownerId
+            }
         },
         controlPort = object : ControlPort {
             override fun sendDispatchCommand(

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
@@ -22,7 +22,7 @@ class CarStateServiceTest {
                 calls += "remove:$carId"
             }
 
-            override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+            override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
         }, noopVehicleLocationStreamService())
 
         service.handle(
@@ -55,7 +55,7 @@ class CarStateServiceTest {
                 calls += "remove:$carId"
             }
 
-            override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+            override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
         }, noopVehicleLocationStreamService())
 
         service.handle(
@@ -88,7 +88,7 @@ class CarStateServiceTest {
                 calls += "remove:$carId"
             }
 
-            override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+            override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
         }, noopVehicleLocationStreamService())
 
         service.handle(

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/ConfirmDispatchServiceTest.kt
@@ -5,6 +5,7 @@ import com.baro.dispatch.application.port.out.DirectionsPort
 import com.baro.dispatch.application.port.out.DispatchableCarCandidate
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
 import com.baro.dispatch.application.port.out.RouteEstimate
+import com.baro.dispatch.application.port.out.VehicleReservationPort
 import com.baro.dispatch.domain.model.Dispatch
 import com.baro.dispatch.domain.model.DispatchRequest
 import com.baro.dispatch.domain.model.DispatchRequestStatus
@@ -28,6 +29,7 @@ class ConfirmDispatchServiceTest {
         var savedDispatch: Dispatch? = null
         var updatedPreRequest: DispatchRequest? = null
         val removedCars = mutableListOf<Long>()
+        val vehicleReservationPort = vehicleReservationPortWithReservationResult(true)
         val preRequest = DispatchRequest.pending(
             userId = 2L,
             origin = GeoPoint(longitude = 127.1, latitude = 37.4),
@@ -56,6 +58,7 @@ class ConfirmDispatchServiceTest {
                 override fun findActiveByCarId(carId: Long): Dispatch? = null
             },
             dispatchableCarProjection = dispatchableCarProjectionWith(101L, removedCars),
+            vehicleReservationPort = vehicleReservationPort,
             directionsPort = noopDirectionsPort(),
             controlPort = noopControlPort(),
             pendingDispatchStore = PendingDispatchStore(),
@@ -104,6 +107,7 @@ class ConfirmDispatchServiceTest {
                 override fun findActiveByCarId(carId: Long): Dispatch? = null
             },
             dispatchableCarProjection = dispatchableCarProjectionWith(101L),
+            vehicleReservationPort = vehicleReservationPortWithReservationResult(true),
             directionsPort = noopDirectionsPort(),
             controlPort = noopControlPort(),
             pendingDispatchStore = PendingDispatchStore(),
@@ -137,7 +141,7 @@ class ConfirmDispatchServiceTest {
         ).copy(id = 1L, status = DispatchRequestStatus.MATCHED)
         val service = ConfirmDispatchService(
             dispatchRequestRepository = object : DispatchRequestRepository {
-                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun save(request: DispatchRequest): Long = requireNotNull(request.id)
                 override fun findById(requestId: Long): DispatchRequest? = preRequest
             },
             dispatchRepository = object : DispatchRepository {
@@ -147,6 +151,7 @@ class ConfirmDispatchServiceTest {
                 override fun findActiveByCarId(carId: Long): Dispatch? = null
             },
             dispatchableCarProjection = dispatchableCarProjectionWith(101L),
+            vehicleReservationPort = vehicleReservationPortWithReservationResult(true),
             directionsPort = noopDirectionsPort(),
             controlPort = noopControlPort(),
             pendingDispatchStore = PendingDispatchStore(),
@@ -180,7 +185,7 @@ class ConfirmDispatchServiceTest {
         ).copy(id = 1L)
         val service = ConfirmDispatchService(
             dispatchRequestRepository = object : DispatchRequestRepository {
-                override fun save(request: DispatchRequest): Long = error("사용하지 않습니다.")
+                override fun save(request: DispatchRequest): Long = requireNotNull(request.id)
                 override fun findById(requestId: Long): DispatchRequest? = preRequest
             },
             dispatchRepository = object : DispatchRepository {
@@ -190,6 +195,7 @@ class ConfirmDispatchServiceTest {
                 override fun findActiveByCarId(carId: Long): Dispatch? = null
             },
             dispatchableCarProjection = dispatchableCarProjectionWith(101L),
+            vehicleReservationPort = vehicleReservationPortWithReservationResult(true),
             directionsPort = noopDirectionsPort(),
             controlPort = noopControlPort(),
             pendingDispatchStore = PendingDispatchStore(),
@@ -233,6 +239,7 @@ class ConfirmDispatchServiceTest {
                 override fun findActiveByCarId(carId: Long): Dispatch? = null
             },
             dispatchableCarProjection = dispatchableCarProjectionWith(null),
+            vehicleReservationPort = vehicleReservationPortWithReservationResult(true),
             directionsPort = noopDirectionsPort(),
             controlPort = noopControlPort(),
             pendingDispatchStore = PendingDispatchStore(),
@@ -252,14 +259,79 @@ class ConfirmDispatchServiceTest {
         assertEquals("배차 가능한 차량을 찾을 수 없습니다.", exception.message)
     }
 
+    @Test
+    fun `첫 번째 차량 예약이 실패하고 두 번째 차량 예약이 성공하면 두 번째 차량으로 배차한다`() {
+        val reservationAttempts = mutableListOf<Long>()
+        val vehicleReservationPort = object : VehicleReservationPort {
+            override fun reserve(carId: Long, ownerId: String): Boolean {
+                reservationAttempts += carId
+                return carId == 202L
+            }
+
+            override fun release(carId: Long, ownerId: String) = Unit
+        }
+        val preRequest = DispatchRequest.pending(
+            userId = 2L,
+            origin = GeoPoint(longitude = 127.1, latitude = 37.4),
+            destination = GeoPoint(longitude = 127.2, latitude = 37.5),
+            fare = 12_100,
+            routePath = emptyList(),
+            estimatedTime = 46,
+            distanceKm = 13.8,
+            now = OffsetDateTime.ofInstant(Instant.parse("2026-04-27T00:00:00Z"), ZoneOffset.UTC),
+        ).copy(id = 1L)
+        val service = ConfirmDispatchService(
+            dispatchRequestRepository = object : DispatchRequestRepository {
+                override fun save(request: DispatchRequest): Long = requireNotNull(request.id)
+                override fun findById(requestId: Long): DispatchRequest? = preRequest
+            },
+            dispatchRepository = object : DispatchRepository {
+                override fun save(dispatch: Dispatch): Long = 10L
+                override fun findById(dispatchId: Long): Dispatch? = null
+                override fun update(dispatch: Dispatch) = Unit
+                override fun findActiveByCarId(carId: Long): Dispatch? = null
+            },
+            dispatchableCarProjection = object : DispatchableCarProjection {
+                override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) = Unit
+                override fun removeCar(carId: Long) = Unit
+                override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = listOf(
+                    DispatchableCarCandidate(carId = 101L, carNumber = "12가3456", distanceKm = 0.3, latitude = 37.4, longitude = 127.0),
+                    DispatchableCarCandidate(carId = 202L, carNumber = "34나5678", distanceKm = 0.5, latitude = 37.41, longitude = 127.01),
+                )
+            },
+            vehicleReservationPort = vehicleReservationPort,
+            directionsPort = noopDirectionsPort(),
+            controlPort = noopControlPort(),
+            pendingDispatchStore = PendingDispatchStore(),
+            transactionTemplate = TransactionTemplate(object : PlatformTransactionManager {
+                override fun getTransaction(definition: org.springframework.transaction.TransactionDefinition?) =
+                    org.springframework.transaction.support.SimpleTransactionStatus()
+                override fun commit(status: org.springframework.transaction.TransactionStatus) = Unit
+                override fun rollback(status: org.springframework.transaction.TransactionStatus) = Unit
+            }),
+            clock = Clock.fixed(Instant.parse("2026-04-27T00:05:00Z"), ZoneOffset.UTC),
+        )
+
+        val result = service.confirm(ConfirmDispatchCommand(requestId = 1L, userId = 2L))
+
+        assertEquals(202L, result.carId)
+        assertEquals(listOf(101L, 202L), reservationAttempts)
+    }
+
     private fun dispatchableCarProjectionWith(
         carId: Long?,
         removedCars: MutableList<Long> = mutableListOf(),
     ): DispatchableCarProjection = object : DispatchableCarProjection {
         override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) = Unit
         override fun removeCar(carId: Long) { removedCars += carId }
-        override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? =
-            carId?.let { DispatchableCarCandidate(carId = it, carNumber = "12가3456", distanceKm = 0.3, latitude = 37.4, longitude = 127.0) }
+        override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> =
+            carId?.let { listOf(DispatchableCarCandidate(carId = it, carNumber = "12가3456", distanceKm = 0.3, latitude = 37.4, longitude = 127.0)) }
+                ?: emptyList()
+    }
+
+    private fun vehicleReservationPortWithReservationResult(reserved: Boolean): VehicleReservationPort = object : VehicleReservationPort {
+        override fun reserve(carId: Long, ownerId: String): Boolean = reserved
+        override fun release(carId: Long, ownerId: String) = Unit
     }
 
     private fun noopDirectionsPort(): DirectionsPort = object : DirectionsPort {

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
@@ -19,7 +19,7 @@ class CarStateConsumerTest {
             object : CarStateService(object : DispatchableCarProjection {
                 override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) = Unit
                 override fun removeCar(carId: Long) = Unit
-                override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+                override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
             }, noopVehicleLocationStreamService()) {
                 override fun handle(command: CarStateCommand) {
                     received = command
@@ -66,7 +66,7 @@ class CarStateConsumerTest {
             object : CarStateService(object : DispatchableCarProjection {
                 override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) = Unit
                 override fun removeCar(carId: Long) = Unit
-                override fun findNearestIdleCar(latitude: Double, longitude: Double): DispatchableCarCandidate? = null
+                override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
             }, noopVehicleLocationStreamService()) {
                 override fun handle(command: CarStateCommand) {
                     received = command


### PR DESCRIPTION
## 요약

배차 확정/재배차 과정에서 같은 차량이 동시에 여러 배차에 선택되는 race condition을 줄이기 위해 Redis 기반 차량 선점(reservation)을 추가했습니다.

이번 변경은 다음 문제를 완화합니다.

```text
요청 A: Redis GEO에서 차량 101 조회
요청 B: Redis GEO에서 차량 101 조회
A/B 모두 같은 차량으로 배차 확정 시도
```

이제 배차 후보를 찾은 뒤 곧바로 차량별 reservation key를 `SET NX PX` 방식으로 선점하고, 선점에 성공한 요청만 해당 차량으로 배차를 진행합니다.

---

## 아키텍처 변화 비교

### 1. 모놀리틱 구조

모놀리틱 구조는 하나의 애플리케이션 안에 사용자, 배차, 관제, 재배치 같은 기능을 모두 포함하는 방식입니다.

장점:

- 개발 초기 속도가 빠릅니다.
- 배포 단위가 하나라 운영 구성이 단순합니다.
- 서비스 간 호출이 프로세스 내부 메서드 호출이므로 네트워크 지연이나 직렬화 비용이 거의 없습니다.
- 하나의 DB 트랜잭션으로 여러 도메인 변경을 묶기 쉽습니다.
- 장애 원인 추적이 비교적 단순합니다.

트레이드오프:

- 코드베이스가 커질수록 도메인 경계가 흐려지기 쉽습니다.
- 특정 기능 변경이 전체 애플리케이션 배포로 이어집니다.
- 트래픽이 많은 기능만 독립적으로 확장하기 어렵습니다.
- 팀이 커질수록 병렬 개발 충돌이 늘어납니다.
- 한 영역의 장애가 전체 애플리케이션 장애로 번질 수 있습니다.

적합한 상황:

- 초기 제품 개발
- 도메인 경계가 아직 불명확한 단계
- 팀 규모가 작고 배포/운영 복잡도를 낮춰야 하는 단계

---

### 2. 멀티모듈 + common 모듈 구조

멀티모듈 구조는 하나의 저장소/빌드 안에서 기능별 모듈을 나누고, 공통 예외/웹 설정/외부 API 클라이언트 같은 기술 요소를 common 모듈로 분리하는 방식입니다.

장점:

- 모놀리틱보다 코드 경계를 명확히 할 수 있습니다.
- Gradle 모듈 의존성으로 잘못된 참조를 어느 정도 차단할 수 있습니다.
- 공통 웹 응답, 예외 처리, Jackson 설정, 외부 API raw client 같은 중복을 줄일 수 있습니다.
- 여전히 하나의 저장소에서 변경을 추적하므로 개발 경험은 단순하게 유지됩니다.
- MSA 전환 전 도메인 경계를 검증하기 좋습니다.

트레이드오프:

- 런타임은 여전히 강하게 묶일 수 있습니다.
- common 모듈이 커지면 도메인 결합이 다시 증가합니다.
- 공통화 기준이 불명확하면 특정 서비스의 비즈니스 로직이 common으로 새어 들어갈 수 있습니다.
- 빌드/테스트 범위가 커질 수 있습니다.
- 배포 단위가 완전히 분리되지 않으면 독립 확장 효과는 제한됩니다.

적합한 상황:

- 모놀리틱에서 도메인 경계를 정리하는 단계
- 중복 기술 설정을 줄이되, 운영 복잡도는 크게 늘리고 싶지 않은 단계
- 향후 MSA 전환 가능성을 열어두는 단계

---

### 3. MSA + Spring Cloud Gateway 구조

MSA 구조는 user-service, dispatch-service, control-service, relocation-service처럼 비즈니스 기능을 독립 서비스로 분리하고, Spring Cloud Gateway가 외부 진입점과 라우팅/인증을 담당하는 방식입니다.

장점:

- 서비스별 독립 배포가 가능합니다.
- 트래픽이 많은 서비스만 별도로 확장할 수 있습니다.
- 서비스별 장애 격리가 쉬워집니다.
- 각 서비스가 자기 도메인 모델과 DB/저장소 책임을 독립적으로 가질 수 있습니다.
- Gateway에서 외부 인증, CORS, 라우팅, public/internal 경로 차단 같은 edge 책임을 중앙화할 수 있습니다.
- 서비스 간 경계를 REST internal API, Kafka 이벤트, 외부 API port 같은 명시적 계약으로 표현할 수 있습니다.

트레이드오프:

- 네트워크 호출, timeout, retry, circuit breaker, 관측성 같은 분산 시스템 문제가 추가됩니다.
- 단일 DB 트랜잭션으로 처리하던 작업을 서비스 간 정합성 전략으로 바꿔야 합니다.
- 배포, CI/CD, 인프라, 로그/트레이싱 운영 복잡도가 증가합니다.
- 서비스 간 API 계약 관리가 중요해집니다.
- 중복 모델을 무리하게 common으로 올리면 MSA의 독립성이 약해집니다.
- Gateway가 비즈니스 판단을 갖기 시작하면 edge 계층과 도메인 계층의 책임이 섞일 수 있습니다.

적합한 상황:

- 서비스별 트래픽/배포/장애 특성이 달라진 단계
- 팀 또는 기능 영역이 독립적으로 움직여야 하는 단계
- 운영 복잡도를 감당할 수 있는 관측성/인프라 기반이 있는 단계

---

## 현재 구조 설명

현재 프로젝트는 MSA + Spring Cloud Gateway 구조를 기준으로 정리되어 있습니다.

### 서비스 구성

- `gateway-service`
  - 외부 요청의 단일 진입점입니다.
  - JWT 인증을 수행합니다.
  - 인증된 사용자 정보를 downstream 서비스에 `X-Authenticated-User-Id`, `X-Authenticated-Email` 헤더로 전달합니다.
  - `/user/**`, `/dispatch/**`, `/control/**`, `/relocation/assign` 경로를 각 서비스로 라우팅합니다.
  - `/internal/**` 같은 내부 API는 외부 Gateway에서 기본 차단합니다.
  - 비즈니스 로직, 서비스별 DTO 변환, 도메인 판단은 포함하지 않습니다.

- `user-service`
  - 회원가입, 로그인, 토큰 발급/갱신을 담당합니다.
  - JWT 발급 책임이 있으므로 자체 `JwtProperties`, `JwtTokenProvider`를 유지합니다.

- `dispatch-service`
  - 배차 요청, PRE배차, 배차 확정/취소/재배차 같은 배차 도메인을 담당합니다.
  - DDD 구조를 따릅니다.
  - 도메인 모델과 유스케이스는 서비스 내부에 두고, 외부 연동은 port를 통해 분리합니다.

- `control-service`
  - 차량 상태, 관제 관련 기능을 담당합니다.
  - 외부 Gateway를 통해 필요한 public 업무 API만 노출하고, 내부 callback/API는 외부에 노출하지 않는 방향입니다.

- `relocation-service`
  - 재배치 관련 기능을 담당합니다.
  - 내부 API는 Gateway public route로 직접 노출하지 않는 것을 원칙으로 합니다.

---

### common 모듈 구성

- `common-core`
  - Spring 의존성을 최소화한 공통 예외 베이스와 안정적인 공통 계약만 둡니다.
  - shared-kernel처럼 작고 안정적인 범위만 유지합니다.

- `common-web`
  - Spring MVC 기반 서비스의 공통 웹 설정을 담당합니다.
  - REST 예외 응답, validation 예외 처리, Jackson snake_case, OpenAPI, Clock 설정 등을 포함합니다.
  - WebFlux 기반인 `gateway-service`는 직접 의존하지 않습니다.

- `common-kakao`
  - 여러 서비스가 사용하는 카카오 API HTTP 클라이언트, 설정, 외부 응답 DTO를 둡니다.
  - 외부 API 호출과 raw response 모델까지만 제공하고, 서비스별 use case 변환은 각 서비스가 담당합니다.

현재 common 모듈은 서비스 독립적인 기술 계약 중심으로만 사용합니다. 서비스별 도메인 모델, JPA Entity, 유스케이스 DTO는 common으로 올리지 않습니다.

---

### dispatch-service 내부 구조

`dispatch-service`는 DDD 계층 구조를 따릅니다.

- `domain`
  - 배차 도메인 모델, 도메인 예외, repository 계약을 둡니다.

- `application`
  - 유스케이스 서비스를 둡니다.
  - 외부 시스템 연동은 port interface로 표현합니다.
  - 예: `VehicleReservationPort`, `DispatchableCarProjection`, `ControlPort`

- `infrastructure`
  - DB, Redis, 외부 API, 설정 같은 기술 구현체를 둡니다.
  - 예: `RedisVehicleReservationAdapter`, `RedisDispatchableCarProjection`

- `interfaces.rest`
  - REST Controller, REST DTO, REST 예외 핸들러를 둡니다.

이번 PR의 Redis reservation도 이 구조를 따릅니다.

```text
application port: VehicleReservationPort
infrastructure adapter: RedisVehicleReservationAdapter
application service: ConfirmDispatchService / DispatchRetryService / CancelDispatchService
```

즉, 배차 유스케이스는 “차량을 선점한다”는 의도만 알고, Redis `SET NX PX`나 Lua release 같은 기술 세부사항은 infrastructure에 숨깁니다.

---

## 주요 변경

### 1. Redis 차량 선점 포트 추가

추가 파일:

- `VehicleReservationPort`
- `RedisVehicleReservationAdapter`

동작 방식:

```text
SET dispatch:vehicle:reservation:{carId} {ownerId} NX PX {ttl}
```

- key가 없을 때만 생성됩니다.
- TTL 기본값은 30초입니다.
- 선점 성공 시에만 해당 차량으로 배차/재배차를 진행합니다.
- 선점 실패 시 다음 후보 차량을 시도합니다.

해제는 owner-safe 하게 처리했습니다.

```lua
if redis.call('GET', KEYS[1]) == ARGV[1] then
  return redis.call('DEL', KEYS[1])
end
return 0
```

즉, 다른 요청이 잡은 reservation key를 잘못 지우지 않습니다.

---

### 2. 배차 확정 흐름에 reservation 적용

대상:

- `ConfirmDispatchService`

변경 전:

```text
Redis GEO에서 가장 가까운 차량 1대 조회
→ 경로 계산
→ dispatch 저장
→ Redis GEO에서 차량 제거
→ control-service 명령 전송
```

변경 후:

```text
Redis GEO 후보 목록 조회
→ 후보 차량마다 reservation 시도
→ 선점 성공 차량으로 경로 계산
→ DB 저장
→ Redis GEO에서 차량 제거
→ pending 등록
→ control-service 명령 전송
```

보완한 실패 처리:

- 경로 계산 실패 시 reservation release
- DB 저장 실패 시 reservation release
- 선점 실패한 후보는 건너뛰고 다음 후보를 시도

---

### 3. 재배차 흐름에 reservation 적용

대상:

- `DispatchRetryService`

ACK timeout으로 재배차할 때도 동일하게 차량 선점을 적용했습니다.

보완한 실패 처리:

- request 조회 실패 시 reservation release
- 경로 계산 실패 시 reservation release
- dispatch update/Redis 제거 실패 시 새 차량 reservation release
- 재배차 성공 후 기존 차량 reservation 즉시 release

또한 빠른 ACK가 pending 등록보다 먼저 도착해 유실되는 가능성을 줄이기 위해, `pendingStore.register(...)` 후 `controlPort.sendDispatchCommand(...)`를 호출하도록 순서를 조정했습니다.

---

### 4. 취소 시 reservation 정리

대상:

- `CancelDispatchService`

배차 취소 후 차량을 idle projection으로 복구할 때 남아 있을 수 있는 reservation key도 정리합니다.

해제 대상 ownerId:

```text
dispatch-request:{requestId}
dispatch-retry:{dispatchId}
```

TTL로 자동 만료되긴 하지만, 취소 직후 차량이 다시 배차 가능해지는 상황에서 불필요하게 30초 동안 선점 key가 남는 문제를 줄입니다.

---

### 5. Redis GEO 후보 조회 확장 및 최적화

대상:

- `DispatchableCarProjection`
- `RedisDispatchableCarProjection`

변경 전:

```kotlin
fun findNearestIdleCar(...): DispatchableCarCandidate?
```

변경 후:

```kotlin
fun findNearestIdleCars(...): List<DispatchableCarCandidate>
```

기존 호환용으로 `findNearestIdleCar()` 기본 구현은 남겨두었습니다.

이 변경으로 배차 서비스가 다음 후보까지 reservation을 시도할 수 있습니다.

검색 반경 기본값은 다음과 같습니다.

```yaml
dispatch:
  redis:
    idle-car-search-radii-km: ${DISPATCH_REDIS_IDLE_CAR_SEARCH_RADII_KM:5.0,10.0,15.0}
```

코드리뷰 반영으로 Redis GEO 조회는 반경별 반복 조회 대신 최대 반경 1회 조회로 최적화했습니다.

```text
기존: 5km 조회 → 10km 조회 → 15km 조회
변경: 최대 반경 15km 1회 조회
```

Redis GEO 검색은 거리순 정렬을 사용하므로 최대 반경 1회 조회로도 가까운 차량 우선 후보 목록을 얻을 수 있습니다.

---

## 코드리뷰 반영

Gemini Code Assist 리뷰 코멘트 2건을 반영했습니다.

1. 재배차 성공 후 기존 차량 reservation 즉시 해제
   - 기존 차량이 TTL 만료 전까지 불필요하게 선점 상태로 남는 문제를 줄였습니다.

2. Redis GEO 후보 조회 최적화
   - 설정된 반경을 순회하며 여러 번 Redis에 조회하던 방식을 최대 반경 1회 조회로 변경했습니다.
   - Redis 네트워크 왕복과 부하를 줄였습니다.

리뷰 스레드는 모두 resolve 처리했습니다.

---

## 테스트

수정/추가한 테스트:

- `ConfirmDispatchServiceTest`
  - reservation 성공 경로 반영
  - reservation 실패 시 “배차 가능한 차량을 찾을 수 없습니다.” 검증
  - 첫 번째 후보 선점 실패 후 두 번째 후보 선점 성공 시 두 번째 차량 배차 검증
- `CancelDispatchServiceTest`
  - 취소 시 reservation release 검증
- `CarStateServiceTest`
- `CarStateConsumerTest`
- `CancelDispatchServiceTest`
  - `DispatchableCarProjection` 인터페이스 변경 반영

검증 명령:

```bash
./gradlew :dispatch-service:clean :dispatch-service:build
```

결과:

```text
BUILD SUCCESSFUL
```

GitHub Actions 결과:

- Dispatch Service CI 성공
- 변경 없는 다른 서비스 CI는 변경 감지에 따라 skip

---

## 의도적으로 이번 PR에 포함하지 않은 것

### DB partial unique index / 조건부 update

Redis reservation은 race condition을 줄이는 빠른 선점 장치이고, 최종 정합성은 DB 제약으로 한 번 더 막는 것이 가장 안전합니다.

예를 들면 추후 아래 같은 제약이 필요합니다.

```sql
CREATE UNIQUE INDEX uk_active_dispatch_car
ON dispatch (car_id)
WHERE dispatch_status IN ('REQUESTED', 'ASSIGNED');
```

또는 PRE배차 상태 전이를 조건부 update로 처리하는 방식도 고려할 수 있습니다.

다만 현재 프로젝트에는 Flyway/Liquibase 같은 명시적 DB migration 구조가 없고, dev는 `ddl-auto=update` 중심으로 운영 중입니다. 운영/개발 DB에 안전하게 적용하려면 migration 전략 합의가 먼저 필요하므로 이번 PR에서는 제외했습니다.

후속 작업 후보:

- DB migration 도입 또는 기존 migration 전략 확인
- active dispatch 차량 중복 방지 partial unique index 추가
- `PENDING -> MATCHED` 조건부 update 또는 optimistic lock 적용
- dispatch 생성 중 unique constraint 위반 시 다음 후보 재시도 처리

---

## 주의사항

- reservation TTL 기본값은 30초입니다.
- 경로 계산이나 DB 저장이 30초 이상 걸리면 reservation이 만료될 수 있습니다. 현재는 race 완화 목적이며, 최종 방어는 DB 제약이 필요합니다.
- Redis GEO 제거는 DB 저장 이후 수행하도록 조정했습니다. DB 트랜잭션 안에는 Redis 조작을 넣지 않는 방향입니다.
