### PR TITLE
리팩토링: Gemini 코드 리뷰 반영

### DIFF
--- a/control-service/src/main/kotlin/com/baro/control/client/RelocationServiceClient.kt
+++ b/control-service/src/main/kotlin/com/baro/control/client/RelocationServiceClient.kt
@@ -10,10 +10,11 @@ import java.time.Duration
 
 @Component
 class RelocationServiceClient(
+    restClientBuilder: RestClient.Builder,
     @Value("\${relocation.service.url}") baseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val client = RestClient.builder()
+    private val client = restClientBuilder
         .baseUrl(baseUrl)
         .requestFactory(
             JdkClientHttpRequestFactory(

--- a/control-service/src/main/kotlin/com/baro/control/client/RelocationServiceClient.kt
+++ b/control-service/src/main/kotlin/com/baro/control/client/RelocationServiceClient.kt
@@ -14,7 +14,7 @@ class RelocationServiceClient(
     @Value("\${relocation.service.url}") baseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val client = restClientBuilder
+    private val client = restClientBuilder.clone()
         .baseUrl(baseUrl)
         .requestFactory(
             JdkClientHttpRequestFactory(

--- a/control-service/src/main/kotlin/com/baro/control/service/EventService.kt
+++ b/control-service/src/main/kotlin/com/baro/control/service/EventService.kt
@@ -26,13 +26,17 @@ class EventService(
                     val carId = vehicleId.toLongOrNull()
                     val state = vehicleStateStore.find(vehicleId)
                     if (carId != null && state != null) {
-                        CompletableFuture.runAsync({
-                            try {
-                                relocationClient.notifyVehicleCompleted(carId, state.latitude, state.longitude)
-                            } catch (e: Exception) {
-                                log.warn("재배치 서비스 통보 실패 (무시). carId={}", carId, e)
-                            }
-                        }, taskExecutor)
+                        try {
+                            CompletableFuture.runAsync({
+                                try {
+                                    relocationClient.notifyVehicleCompleted(carId, state.latitude, state.longitude)
+                                } catch (e: Exception) {
+                                    log.warn("재배치 서비스 통보 실패 (무시). carId={}", carId, e)
+                                }
+                            }, taskExecutor)
+                        } catch (e: Exception) {
+                            log.error("재배치 비동기 작업 제출 실패. carId={}", carId, e)
+                        }
                     } else {
                         log.warn("차량 상태를 찾을 수 없어 재배치 생략. vehicleId={}", vehicleId)
                     }

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/DispatchServiceApplicationTests.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/DispatchServiceApplicationTests.kt
@@ -6,11 +6,10 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest(
     properties = [
         "baro.jwt.secret=test-jwt-secret-must-be-at-least-32-bytes",
-        "REDIS_HOST=localhost",
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
         "DISPATCH_DB_URL=jdbc:h2:mem:testdb",
         "DISPATCH_DB_USERNAME=sa",
         "DISPATCH_DB_PASSWORD=",
-        "KAFKA_BOOTSTRAP_SERVERS=localhost:9092",
         "spring.jpa.hibernate.ddl-auto=none",
     ],
 )

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/DispatchServiceApplicationTests.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/DispatchServiceApplicationTests.kt
@@ -6,11 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest(
     properties = [
         "baro.jwt.secret=test-jwt-secret-must-be-at-least-32-bytes",
-        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration",
-        "DISPATCH_DB_URL=jdbc:h2:mem:testdb",
-        "DISPATCH_DB_USERNAME=sa",
-        "DISPATCH_DB_PASSWORD=",
-        "spring.jpa.hibernate.ddl-auto=none",
     ],
 )
 class DispatchServiceApplicationTests {

--- a/relocation-service/src/main/kotlin/com/baro/relocation/client/ControlServiceClient.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/client/ControlServiceClient.kt
@@ -10,10 +10,11 @@ import java.time.Duration
 
 @Component
 class ControlServiceClient(
+    restClientBuilder: RestClient.Builder,
     @Value("\${control.service.url}") baseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val client = RestClient.builder()
+    private val client = restClientBuilder
         .baseUrl(baseUrl)
         .requestFactory(
             JdkClientHttpRequestFactory(

--- a/relocation-service/src/main/kotlin/com/baro/relocation/client/ControlServiceClient.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/client/ControlServiceClient.kt
@@ -14,7 +14,7 @@ class ControlServiceClient(
     @Value("\${control.service.url}") baseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val client = restClientBuilder
+    private val client = restClientBuilder.clone()
         .baseUrl(baseUrl)
         .requestFactory(
             JdkClientHttpRequestFactory(

--- a/relocation-service/src/main/kotlin/com/baro/relocation/controller/RelocationController.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/controller/RelocationController.kt
@@ -35,13 +35,18 @@ class RelocationController(
 
     @PostMapping("/internal/vehicle-completed")
     fun vehicleCompleted(@RequestBody request: VehicleCompleteRequest): ResponseEntity<Void> {
-        CompletableFuture.runAsync({
-            try {
-                relocationTriggerService.triggerRelocation(request.carId, request.lat, request.lon)
-            } catch (e: Exception) {
-                log.warn("재배치 트리거 실패 (무시). carId={}", request.carId, e)
-            }
-        }, taskExecutor)
+        try {
+            CompletableFuture.runAsync({
+                try {
+                    relocationTriggerService.triggerRelocation(request.carId, request.lat, request.lon)
+                } catch (e: Exception) {
+                    log.warn("재배치 트리거 실패 (무시). carId={}", request.carId, e)
+                }
+            }, taskExecutor)
+        } catch (e: Exception) {
+            log.error("재배치 트리거 비동기 작업 제출 실패. carId={}", request.carId, e)
+            return ResponseEntity.status(503).build()
+        }
         return ResponseEntity.accepted().build()
     }
 }

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationTriggerService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationTriggerService.kt
@@ -36,8 +36,8 @@ class RelocationTriggerService(
         val routePoints = route.sections.flatMap { section ->
             section.roads.flatMap { road ->
                 val vertexes = road.vertexes
-                (0 until vertexes.size - 1 step 2).map { i ->
-                    mapOf("lat" to vertexes[i + 1], "lon" to vertexes[i])
+                vertexes.chunked(2).mapNotNull { chunk ->
+                    if (chunk.size == 2) mapOf("lat" to chunk[1], "lon" to chunk[0]) else null
                 }
             }
         }

--- a/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationTriggerService.kt
+++ b/relocation-service/src/main/kotlin/com/baro/relocation/service/RelocationTriggerService.kt
@@ -37,7 +37,7 @@ class RelocationTriggerService(
             section.roads.flatMap { road ->
                 val vertexes = road.vertexes
                 (0 until vertexes.size - 1 step 2).map { i ->
-                    mapOf("lat" to vertexes[i + 1], "lng" to vertexes[i])
+                    mapOf("lat" to vertexes[i + 1], "lon" to vertexes[i])
                 }
             }
         }

--- a/relocation-service/src/test/kotlin/com/baro/relocation/SaveWeightServiceApplicationTests.kt
+++ b/relocation-service/src/test/kotlin/com/baro/relocation/SaveWeightServiceApplicationTests.kt
@@ -3,15 +3,7 @@ package com.baro.relocation
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest(
-    properties = [
-        "RELOCATION_DB_URL=jdbc:h2:mem:testdb",
-        "RELOCATION_DB_USERNAME=sa",
-        "RELOCATION_DB_PASSWORD=",
-        "CONTROL_SERVICE_URL=http://localhost:8081",
-        "spring.jpa.hibernate.ddl-auto=none",
-    ],
-)
+@SpringBootTest
 class SaveWeightServiceApplicationTests {
     @Test
     fun `스프링 컨텍스트가 정상적으로 로드된다`() {


### PR DESCRIPTION
- CompletableFuture.runAsync 제출 실패 시 outer try-catch 추가 (EventService, RelocationController)
- RelocationController: RejectedExecutionException 발생 시 503 반환
- RestClient.Builder 빈 주입 방식으로 변경 (RelocationServiceClient, ControlServiceClient)
- 좌표 키 'lng' → 'lon' 통일 (RelocationTriggerService)
- DispatchServiceApplicationTests: Redis/Kafka 자동설정 제외 방식으로 변경
- SaveWeightServiceApplicationTests: test yml 기반으로 단순화
