### PR TITLE
feat: 게이트웨이 엣지 정책 강화

### DIFF
--- a/gateway-service/build.gradle.kts
+++ b/gateway-service/build.gradle.kts
@@ -11,7 +11,9 @@ dependencyManagement {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
     implementation("org.springframework.security:spring-security-oauth2-jose")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     testImplementation("io.projectreactor:reactor-test")
 }

--- a/gateway-service/src/main/kotlin/com/baro/gateway/observability/AccessLogGlobalFilter.kt
+++ b/gateway-service/src/main/kotlin/com/baro/gateway/observability/AccessLogGlobalFilter.kt
@@ -1,0 +1,44 @@
+package com.baro.gateway.observability
+
+import org.slf4j.LoggerFactory
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.GlobalFilter
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.time.Instant
+
+@Component
+class AccessLogGlobalFilter : GlobalFilter, Ordered {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
+        val startedAt = Instant.now()
+
+        return chain.filter(exchange)
+            .doFinally {
+                val request = exchange.request
+                val response = exchange.response
+                val routeId = exchange.getAttribute<org.springframework.cloud.gateway.route.Route>(GATEWAY_ROUTE_ATTR)?.id
+                    ?: "unmatched"
+                val requestId = request.headers.getFirst(GatewayRequestHeaders.REQUEST_ID) ?: "unknown"
+                val status = response.statusCode?.value() ?: 0
+                val latencyMs = Duration.between(startedAt, Instant.now()).toMillis()
+
+                log.info(
+                    "gateway_access request_id={} method={} path={} route_id={} status={} latency_ms={}",
+                    requestId,
+                    request.method.name(),
+                    request.path.value(),
+                    routeId,
+                    status,
+                    latencyMs,
+                )
+            }
+    }
+
+    override fun getOrder(): Int = Ordered.HIGHEST_PRECEDENCE + 1
+}

--- a/gateway-service/src/main/kotlin/com/baro/gateway/observability/GatewayRequestHeaders.kt
+++ b/gateway-service/src/main/kotlin/com/baro/gateway/observability/GatewayRequestHeaders.kt
@@ -1,0 +1,5 @@
+package com.baro.gateway.observability
+
+object GatewayRequestHeaders {
+    const val REQUEST_ID = "X-Request-Id"
+}

--- a/gateway-service/src/main/kotlin/com/baro/gateway/observability/RequestIdGlobalFilter.kt
+++ b/gateway-service/src/main/kotlin/com/baro/gateway/observability/RequestIdGlobalFilter.kt
@@ -13,15 +13,20 @@ class RequestIdGlobalFilter : GlobalFilter, Ordered {
     private val allowedRequestId = Regex("^[A-Za-z0-9._:-]{1,128}$")
 
     override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
-        val requestId = exchange.request.headers.getFirst(GatewayRequestHeaders.REQUEST_ID)
-            ?.takeIf { allowedRequestId.matches(it) }
-            ?: UUID.randomUUID().toString()
+        val currentRequestId = exchange.request.headers.getFirst(GatewayRequestHeaders.REQUEST_ID)
+        val requestId = currentRequestId?.takeIf { allowedRequestId.matches(it) }
 
+        if (requestId != null) {
+            exchange.response.headers.set(GatewayRequestHeaders.REQUEST_ID, requestId)
+            return chain.filter(exchange)
+        }
+
+        val newRequestId = UUID.randomUUID().toString()
         val request = exchange.request.mutate()
-            .headers { it[GatewayRequestHeaders.REQUEST_ID] = listOf(requestId) }
+            .headers { it.set(GatewayRequestHeaders.REQUEST_ID, newRequestId) }
             .build()
 
-        exchange.response.headers[GatewayRequestHeaders.REQUEST_ID] = listOf(requestId)
+        exchange.response.headers.set(GatewayRequestHeaders.REQUEST_ID, newRequestId)
 
         return chain.filter(exchange.mutate().request(request).build())
     }

--- a/gateway-service/src/main/kotlin/com/baro/gateway/observability/RequestIdGlobalFilter.kt
+++ b/gateway-service/src/main/kotlin/com/baro/gateway/observability/RequestIdGlobalFilter.kt
@@ -1,0 +1,30 @@
+package com.baro.gateway.observability
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.GlobalFilter
+import org.springframework.core.Ordered
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+@Component
+class RequestIdGlobalFilter : GlobalFilter, Ordered {
+    private val allowedRequestId = Regex("^[A-Za-z0-9._:-]{1,128}$")
+
+    override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
+        val requestId = exchange.request.headers.getFirst(GatewayRequestHeaders.REQUEST_ID)
+            ?.takeIf { allowedRequestId.matches(it) }
+            ?: UUID.randomUUID().toString()
+
+        val request = exchange.request.mutate()
+            .headers { it[GatewayRequestHeaders.REQUEST_ID] = listOf(requestId) }
+            .build()
+
+        exchange.response.headers[GatewayRequestHeaders.REQUEST_ID] = listOf(requestId)
+
+        return chain.filter(exchange.mutate().request(request).build())
+    }
+
+    override fun getOrder(): Int = Ordered.HIGHEST_PRECEDENCE
+}

--- a/gateway-service/src/main/kotlin/com/baro/gateway/security/JwtAuthenticationGatewayFilterFactory.kt
+++ b/gateway-service/src/main/kotlin/com/baro/gateway/security/JwtAuthenticationGatewayFilterFactory.kt
@@ -58,6 +58,7 @@ class JwtAuthenticationGatewayFilterFactory(
 
         val sanitizedRequest = exchange.request.mutate()
             .headers {
+                it.remove(HttpHeaders.AUTHORIZATION)
                 it.remove(GatewayAuthenticationHeaders.USER_ID)
                 it.remove(GatewayAuthenticationHeaders.EMAIL)
             }

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -1,17 +1,38 @@
 server:
   port: ${GATEWAY_PORT:8080}
+  compression:
+    enabled: true
+    min-response-size: 1KB
+    mime-types: application/json,text/plain,text/html,text/css,application/javascript
 
 spring:
   application:
     name: gateway-service
   cloud:
     gateway:
+      httpclient:
+        connect-timeout: 2000
+        response-timeout: 5s
+      default-filters:
+        - SecureHeaders
+        - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin
+        - RequestSize=5MB
+      globalcors:
+        add-to-simple-url-handler-mapping: true
+        cors-configurations:
+          '[/**]':
+            allowed-origin-patterns: ${GATEWAY_CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:3000,http://localhost:5173}
+            allowed-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS
+            allowed-headers: Authorization,Content-Type,X-Request-Id
+            exposed-headers: X-Request-Id
+            allow-credentials: true
+            max-age: 3600
       routes:
         - id: block-internal-api
           uri: no://op
           order: -100
           predicates:
-            - Path=/internal/**,/dispatch/command-ack,/dispatch/arrived
+            - Path=/internal/**,/dispatch/command-ack,/dispatch/arrived,/dispatch/vehicles/*/active
           filters:
             - SetStatus=404
 
@@ -20,12 +41,18 @@ spring:
           predicates:
             - Method=POST
             - Path=/user/auth/sign-up,/user/auth/login,/user/auth/token/refresh
+          filters:
+            - RemoveRequestHeader=Authorization
+            - CircuitBreaker=userServiceCircuitBreaker
 
         - id: user-service-docs
           uri: ${USER_SERVICE_URL:http://localhost:8084}
           predicates:
             - Method=GET
             - Path=/user/swagger-ui.html,/user/swagger-ui/**,/user/api-docs,/user/api-docs/**
+          filters:
+            - RemoveRequestHeader=Authorization
+            - CircuitBreaker=userServiceCircuitBreaker
 
         - id: user-service-authenticated
           uri: ${USER_SERVICE_URL:http://localhost:8084}
@@ -33,18 +60,16 @@ spring:
             - Path=/user/**
           filters:
             - JwtAuthentication
+            - CircuitBreaker=userServiceCircuitBreaker
 
         - id: dispatch-service-docs
           uri: ${DISPATCH_SERVICE_URL:http://localhost:8082}
           predicates:
             - Method=GET
             - Path=/dispatch/swagger-ui.html,/dispatch/swagger-ui/**,/dispatch/api-docs,/dispatch/api-docs/**
-
-        - id: dispatch-service-admin-active
-          uri: ${DISPATCH_SERVICE_URL:http://localhost:8082}
-          predicates:
-            - Method=GET
-            - Path=/dispatch/vehicles/*/active
+          filters:
+            - RemoveRequestHeader=Authorization
+            - CircuitBreaker=dispatchServiceCircuitBreaker
 
         - id: dispatch-service
           uri: ${DISPATCH_SERVICE_URL:http://localhost:8082}
@@ -52,12 +77,26 @@ spring:
             - Path=/dispatch/**
           filters:
             - JwtAuthentication
+            - CircuitBreaker=dispatchServiceCircuitBreaker
 
-        - id: control-service-admin-read
+        - id: control-service-admin-vehicles
           uri: ${CONTROL_SERVICE_URL:http://localhost:8081}
           predicates:
             - Method=GET
-            - Path=/control/vehicles,/control/vehicles/stream
+            - Path=/control/vehicles
+          filters:
+            - RemoveRequestHeader=Authorization
+            - CircuitBreaker=controlServiceCircuitBreaker
+
+        - id: control-service-admin-vehicles-stream
+          uri: ${CONTROL_SERVICE_URL:http://localhost:8081}
+          predicates:
+            - Method=GET
+            - Path=/control/vehicles/stream
+          metadata:
+            response-timeout: -1
+          filters:
+            - RemoveRequestHeader=Authorization
 
         - id: control-service
           uri: ${CONTROL_SERVICE_URL:http://localhost:8081}
@@ -65,12 +104,16 @@ spring:
             - Path=/control/**
           filters:
             - JwtAuthentication
+            - CircuitBreaker=controlServiceCircuitBreaker
 
         - id: relocation-service-docs
           uri: ${RELOCATION_SERVICE_URL:http://localhost:8083}
           predicates:
             - Method=GET
             - Path=/relocation/swagger-ui.html,/relocation/swagger-ui/**,/relocation/api-docs,/relocation/api-docs/**
+          filters:
+            - RemoveRequestHeader=Authorization
+            - CircuitBreaker=relocationServiceCircuitBreaker
 
         - id: relocation-service
           uri: ${RELOCATION_SERVICE_URL:http://localhost:8083}
@@ -78,13 +121,45 @@ spring:
             - Path=/relocation/assign
           filters:
             - JwtAuthentication
+            - CircuitBreaker=relocationServiceCircuitBreaker
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      userServiceCircuitBreaker:
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+      dispatchServiceCircuitBreaker:
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+      controlServiceCircuitBreaker:
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+      relocationServiceCircuitBreaker:
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
 
 baro:
   jwt:
     secret: ${JWT_SECRET:local-test-secret-local-test-secret-local-test-secret}
 
 management:
+  metrics:
+    tags:
+      application: ${spring.application.name}
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: ${GATEWAY_MANAGEMENT_ENDPOINTS:health,info}
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -125,27 +125,21 @@ spring:
 
 resilience4j:
   circuitbreaker:
+    configs:
+      gateway-default:
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
     instances:
       userServiceCircuitBreaker:
-        sliding-window-size: 20
-        minimum-number-of-calls: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
+        base-config: gateway-default
       dispatchServiceCircuitBreaker:
-        sliding-window-size: 20
-        minimum-number-of-calls: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
+        base-config: gateway-default
       controlServiceCircuitBreaker:
-        sliding-window-size: 20
-        minimum-number-of-calls: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
+        base-config: gateway-default
       relocationServiceCircuitBreaker:
-        sliding-window-size: 20
-        minimum-number-of-calls: 10
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10s
+        base-config: gateway-default
 
 baro:
   jwt:

--- a/gateway-service/src/test/kotlin/com/baro/gateway/observability/RequestIdGlobalFilterTest.kt
+++ b/gateway-service/src/test/kotlin/com/baro/gateway/observability/RequestIdGlobalFilterTest.kt
@@ -1,0 +1,79 @@
+package com.baro.gateway.observability
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.http.server.reactive.ServerHttpRequest
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class RequestIdGlobalFilterTest {
+    private val filter = RequestIdGlobalFilter()
+
+    @Test
+    fun `요청에 요청 ID가 없으면 새 값을 요청과 응답 헤더에 넣고 체인을 호출한다`() {
+        val routed = AtomicBoolean(false)
+        val forwardedRequest = AtomicReference<ServerHttpRequest>()
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/dispatch/pre"))
+
+        StepVerifier.create(filter.filter(exchange, chain(routed, forwardedRequest)))
+            .verifyComplete()
+
+        assertTrue(routed.get())
+        val requestId = forwardedRequest.get().headers.getFirst(GatewayRequestHeaders.REQUEST_ID)
+        assertNotNull(requestId)
+        assertEquals(requestId, exchange.response.headers.getFirst(GatewayRequestHeaders.REQUEST_ID))
+    }
+
+    @Test
+    fun `요청에 요청 ID가 있으면 기존 값을 요청과 응답 헤더에 유지하고 체인을 호출한다`() {
+        val routed = AtomicBoolean(false)
+        val forwardedRequest = AtomicReference<ServerHttpRequest>()
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/dispatch/pre")
+                .header(GatewayRequestHeaders.REQUEST_ID, "request-123"),
+        )
+
+        StepVerifier.create(filter.filter(exchange, chain(routed, forwardedRequest)))
+            .verifyComplete()
+
+        assertTrue(routed.get())
+        assertEquals("request-123", forwardedRequest.get().headers.getFirst(GatewayRequestHeaders.REQUEST_ID))
+        assertEquals("request-123", exchange.response.headers.getFirst(GatewayRequestHeaders.REQUEST_ID))
+    }
+
+    @Test
+    fun `요청에 너무 길거나 허용되지 않는 문자 요청 ID가 오면 새 요청 ID를 요청과 응답 헤더에 넣는다`() {
+        val routed = AtomicBoolean(false)
+        val forwardedRequest = AtomicReference<ServerHttpRequest>()
+        val invalidRequestId = "a".repeat(129) + "!"
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/dispatch/pre")
+                .header(GatewayRequestHeaders.REQUEST_ID, invalidRequestId),
+        )
+
+        StepVerifier.create(filter.filter(exchange, chain(routed, forwardedRequest)))
+            .verifyComplete()
+
+        assertTrue(routed.get())
+        val requestId = requireNotNull(forwardedRequest.get().headers.getFirst(GatewayRequestHeaders.REQUEST_ID))
+        assertTrue(requestId != invalidRequestId)
+        assertTrue(Regex("^[A-Za-z0-9._:-]{1,128}$").matches(requestId))
+        assertEquals(requestId, exchange.response.headers.getFirst(GatewayRequestHeaders.REQUEST_ID))
+    }
+
+    private fun chain(
+        routed: AtomicBoolean,
+        forwardedRequest: AtomicReference<ServerHttpRequest>,
+    ): GatewayFilterChain = GatewayFilterChain { exchange ->
+        routed.set(true)
+        forwardedRequest.set(exchange.request)
+        Mono.empty()
+    }
+}

--- a/gateway-service/src/test/kotlin/com/baro/gateway/security/JwtAuthenticationGatewayFilterFactoryTest.kt
+++ b/gateway-service/src/test/kotlin/com/baro/gateway/security/JwtAuthenticationGatewayFilterFactoryTest.kt
@@ -19,10 +19,12 @@ import org.springframework.security.oauth2.jose.jws.MacAlgorithm
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.crypto.spec.SecretKeySpec
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 
 class JwtAuthenticationGatewayFilterFactoryTest {
@@ -59,6 +61,7 @@ class JwtAuthenticationGatewayFilterFactoryTest {
     @Test
     fun `유효한 토큰이면 인증 헤더를 주입하고 라우팅한다`() {
         val routed = AtomicBoolean(false)
+        val forwardedRequest = AtomicReference<org.springframework.http.server.reactive.ServerHttpRequest>()
         val exchange = MockServerWebExchange.from(
             MockServerHttpRequest.get("/dispatch/pre")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer ${token()}" )
@@ -66,20 +69,44 @@ class JwtAuthenticationGatewayFilterFactoryTest {
                 .header(GatewayAuthenticationHeaders.EMAIL, "spoofed@example.com"),
         )
 
-        StepVerifier.create(filterFactory.apply(JwtAuthenticationGatewayFilterFactory.Config()).filter(exchange, chain(routed)))
+        StepVerifier.create(filterFactory.apply(JwtAuthenticationGatewayFilterFactory.Config()).filter(exchange, chain(routed, forwardedRequest)))
             .verifyComplete()
 
         assertTrue(routed.get())
-        assertEquals("7", exchange.request.headers.getFirst(GatewayAuthenticationHeaders.USER_ID))
-        assertEquals("user@example.com", exchange.request.headers.getFirst(GatewayAuthenticationHeaders.EMAIL))
+        assertEquals("7", forwardedRequest.get().headers.getFirst(GatewayAuthenticationHeaders.USER_ID))
+        assertEquals("user@example.com", forwardedRequest.get().headers.getFirst(GatewayAuthenticationHeaders.EMAIL))
+        assertNull(forwardedRequest.get().headers.getFirst(HttpHeaders.AUTHORIZATION))
     }
 
-    private fun chain(routed: AtomicBoolean): GatewayFilterChain = GatewayFilterChain {
+    @Test
+    fun `email claim이 없으면 이메일 헤더를 주입하지 않는다`() {
+        val routed = AtomicBoolean(false)
+        val forwardedRequest = AtomicReference<org.springframework.http.server.reactive.ServerHttpRequest>()
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/dispatch/pre")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(includeEmail = false)}")
+                .header(GatewayAuthenticationHeaders.EMAIL, "spoofed@example.com"),
+        )
+
+        StepVerifier.create(filterFactory.apply(JwtAuthenticationGatewayFilterFactory.Config()).filter(exchange, chain(routed, forwardedRequest)))
+            .verifyComplete()
+
+        assertTrue(routed.get())
+        assertEquals("7", forwardedRequest.get().headers.getFirst(GatewayAuthenticationHeaders.USER_ID))
+        assertNull(forwardedRequest.get().headers.getFirst(GatewayAuthenticationHeaders.EMAIL))
+        assertNull(forwardedRequest.get().headers.getFirst(HttpHeaders.AUTHORIZATION))
+    }
+
+    private fun chain(
+        routed: AtomicBoolean,
+        forwardedRequest: AtomicReference<org.springframework.http.server.reactive.ServerHttpRequest>? = null,
+    ): GatewayFilterChain = GatewayFilterChain { exchange ->
         routed.set(true)
+        forwardedRequest?.set(exchange.request)
         Mono.empty()
     }
 
-    private fun token(): String {
+    private fun token(includeEmail: Boolean = true): String {
         val secretKey = SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256")
         val encoder = NimbusJwtEncoder(
             ImmutableJWKSet<SecurityContext>(
@@ -95,7 +122,11 @@ class JwtAuthenticationGatewayFilterFactoryTest {
                 JwsHeader.with(MacAlgorithm.HS256).build(),
                 JwtClaimsSet.builder()
                     .subject("7")
-                    .claim("email", "user@example.com")
+                    .apply {
+                        if (includeEmail) {
+                            claim("email", "user@example.com")
+                        }
+                    }
                     .issuedAt(Instant.parse("2026-01-01T00:00:00Z"))
                     .expiresAt(Instant.parse("2099-01-01T00:00:00Z"))
                     .build(),


### PR DESCRIPTION
## 개요

Spring Cloud Gateway를 단순 라우터가 아니라 외부 진입점(edge layer)로 더 명확하게 활용하도록 `gateway-service`를 강화했습니다.

이번 변경의 목표는 Gateway가 비즈니스 로직을 갖지 않으면서도, 외부 요청에 대해 공통 보안 정책·라우팅 안정성·관측성을 담당하도록 만드는 것입니다.

## 주요 변경사항

### 1. 인증 헤더 하드닝

- JWT 인증 필터에서 downstream으로 요청을 전달하기 전에 `Authorization` 헤더를 제거했습니다.
- 클라이언트가 임의로 보낸 `X-Authenticated-User-Id`, `X-Authenticated-Email` 헤더는 기존처럼 제거한 뒤, Gateway가 검증한 JWT 값을 기준으로 다시 주입합니다.
- email claim이 없는 경우에는 `X-Authenticated-Email` 헤더를 주입하지 않도록 테스트를 보강했습니다.

이를 통해 downstream 서비스는 외부 클라이언트가 조작한 인증 관련 헤더가 아니라, Gateway가 검증한 사용자 컨텍스트만 신뢰할 수 있습니다.

### 2. 내부 API 차단 강화

- 기존 차단 대상에 `/dispatch/vehicles/*/active`를 추가했습니다.
- 해당 경로는 AGENTS.md 기준 Gateway에서 기본 차단해야 하는 내부/관리 성격의 API이므로 외부 라우트에서 제거했습니다.

### 3. 라우팅 안정성 강화

- Gateway HTTP client에 기본 timeout을 설정했습니다.
  - connection timeout: 2초
  - response timeout: 5초
- 서비스별 CircuitBreaker를 추가했습니다.
  - user-service
  - dispatch-service
  - control-service
  - relocation-service
- `/control/vehicles/stream`은 장기 연결/stream 성격을 고려해 route metadata로 response timeout을 비활성화했습니다.
- public/docs/admin-read 성격의 비인증 route에는 `Authorization` 헤더가 downstream으로 전달되지 않도록 `RemoveRequestHeader=Authorization`을 추가했습니다.

### 4. 공통 Edge 정책 추가

Gateway default filter로 다음 정책을 추가했습니다.

- `SecureHeaders`
- CORS 중복 응답 헤더 정리
- 요청 크기 제한: `5MB`

또한 Gateway 레벨 CORS 정책을 명시했습니다.

- 기본 허용 origin
  - `http://localhost:3000`
  - `http://localhost:5173`
- 운영 환경에서는 `GATEWAY_CORS_ALLOWED_ORIGIN_PATTERNS` 환경변수로 조정할 수 있습니다.

### 5. 응답 압축 설정

JSON/text 계열 응답에 대해 서버 압축을 활성화했습니다.

- 최소 응답 크기: 1KB
- 대상 MIME type:
  - `application/json`
  - `text/plain`
  - `text/html`
  - `text/css`
  - `application/javascript`

### 6. 관측성 추가

요청 추적과 운영 로그를 위해 Gateway 전역 필터를 추가했습니다.

#### Request ID 필터

- `X-Request-Id`가 없으면 Gateway에서 새 UUID를 생성합니다.
- `X-Request-Id`가 있으면 허용된 형식일 때만 유지합니다.
- 허용 형식:
  - 영문/숫자/`.`/`_`/`:`/`-`
  - 최대 128자
- 요청과 응답 모두에 `X-Request-Id`를 세팅합니다.

#### Access Log 필터

민감정보를 남기지 않는 선에서 Gateway access log를 추가했습니다.

로그 필드:

- request id
- method
- path
- route id
- status
- latency ms

Authorization header, JWT, email, body, query string은 로그에 남기지 않습니다.

### 7. Actuator 운영 노출 정책 정리

- 기본 actuator 노출은 기존처럼 `health,info`만 유지했습니다.
- 필요 시 `GATEWAY_MANAGEMENT_ENDPOINTS` 환경변수로 `metrics`, `prometheus`, `gateway` 등을 확장할 수 있습니다.

Gateway는 외부 진입점이므로 운영 endpoint를 기본으로 넓게 열지 않도록 했습니다.

## 테스트

추가/수정한 테스트:

- 유효한 JWT 처리 시 인증 사용자 헤더를 주입하는지 검증
- 클라이언트가 보낸 spoofing 인증 헤더가 제거되는지 검증
- downstream 전달 전 `Authorization` 헤더가 제거되는지 검증
- email claim이 없으면 email 인증 헤더를 주입하지 않는지 검증
- `X-Request-Id`가 없으면 새 요청 ID를 생성하는지 검증
- 유효한 `X-Request-Id`는 유지하는지 검증
- 너무 길거나 허용되지 않는 문자가 포함된 `X-Request-Id`는 새 값으로 대체하는지 검증

검증 명령:

```bash
./gradlew :gateway-service:clean :gateway-service:build
```

결과:

```text
BUILD SUCCESSFUL
```

## 설계상 의도적으로 제외한 것

### Gateway 응답 캐싱

이번 변경에는 Gateway 응답 캐싱을 넣지 않았습니다.

이유:

- 현재 대부분의 API가 인증 사용자 컨텍스트에 의존할 수 있습니다.
- Gateway가 캐시 무효화 정책을 알기 시작하면 서비스별 도메인 로직을 침범할 위험이 있습니다.
- 잘못된 캐싱은 개인정보 노출이나 권한 우회 문제로 이어질 수 있습니다.

추후 공개 GET API 중 사용자별 차이가 없고 TTL이 명확한 경우에만 별도 검토하는 것이 안전합니다.

### Redis 기반 Rate Limit

Rate Limit은 Gateway에 두는 것이 적절하지만, 수평 확장을 고려하면 Redis 등 공유 저장소 기반으로 설계해야 합니다.

이번 PR에서는 Redis 인프라/운영 합의 없이 in-memory rate limit을 추가하지 않았습니다.

## 주의사항

- 운영 환경에서는 `GATEWAY_CORS_ALLOWED_ORIGIN_PATTERNS` 값을 실제 프론트엔드 origin으로 제한해야 합니다.
- `GATEWAY_MANAGEMENT_ENDPOINTS`로 `metrics`, `prometheus`, `gateway` endpoint를 열 경우 외부에 노출되지 않도록 ALB/보안그룹/내부망 정책 확인이 필요합니다.
- CircuitBreaker는 현재 fallback 응답을 만들지 않습니다. Gateway가 도메인 의미를 가진 대체 응답을 만들지 않기 위한 의도입니다.
