### PR TITLE
fix: 게이트웨이 dev CORS 허용

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
         add-to-simple-url-handler-mapping: true
         cors-configurations:
           '[/**]':
-            allowed-origin-patterns: ${GATEWAY_CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:3000,http://localhost:5173}
+            allowed-origin-patterns: ${GATEWAY_CORS_ALLOWED_ORIGIN_PATTERNS:https://dev.barocloud.com,http://localhost:*}
             allowed-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS
             allowed-headers: Authorization,Content-Type,X-Request-Id
             exposed-headers: X-Request-Id


### PR DESCRIPTION
## 개요

Gateway CORS 기본 허용 origin에 dev 프론트엔드 도메인을 추가합니다.

현재 `https://dev.barocloud.com`에서 Gateway로 요청할 때 `Origin: https://dev.barocloud.com`이 전달되지만, Gateway CORS 기본값에는 localhost만 포함되어 있어 라우팅 전에 403 Forbidden이 발생할 수 있습니다.

문제 요청 예:

```text
POST https://dev.barocloud.com/api/auth/sign-up
Origin: https://dev.barocloud.com
Status: 403 Forbidden
```

## 변경사항

Gateway CORS 기본값을 다음과 같이 변경했습니다.

기존:

```yaml
http://localhost:3000,http://localhost:5173
```

변경:

```yaml
https://dev.barocloud.com,http://localhost:*
```

환경변수 `GATEWAY_CORS_ALLOWED_ORIGIN_PATTERNS`가 설정되어 있으면 기존처럼 환경변수 값이 우선됩니다.

## 기대 효과

- dev 배포 환경의 same-origin 프론트 요청이 Gateway CORS에서 차단되지 않습니다.
- 로컬 개발 환경은 `http://localhost:*` 패턴으로 유지됩니다.

## 검증

```bash
env -u JAVA_HOME ./gradlew :gateway-service:build
```

결과:

```text
BUILD SUCCESSFUL
```

## 참고

이번 변경은 Gateway CORS 기본값만 수정합니다. 인증/라우팅 로직은 변경하지 않았습니다.
