### PR TITLE
feat: 서비스 도메인 메트릭 추가

### DIFF
--- a/control-service/build.gradle.kts
+++ b/control-service/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-integration")
     implementation("org.springframework.integration:spring-integration-mqtt")

--- a/control-service/src/main/kotlin/com/baro/control/service/TelemetryService.kt
+++ b/control-service/src/main/kotlin/com/baro/control/service/TelemetryService.kt
@@ -2,6 +2,8 @@ package com.baro.control.service
 
 import com.baro.control.dto.TelemetryPayload
 import com.baro.control.dto.VehicleState
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.core.KafkaTemplate
@@ -11,27 +13,49 @@ import org.springframework.stereotype.Service
 class TelemetryService(
     private val kafkaTemplate: KafkaTemplate<String, Any>,
     private val stateStore: VehicleStateStore,
+    meterRegistry: MeterRegistry,
     @Value("\${kafka.topic.vehicle-data}") private val vehicleDataTopic: String,
 ) {
-    companion object { private val log = LoggerFactory.getLogger(TelemetryService::class.java) }
+    companion object {
+        private val log = LoggerFactory.getLogger(TelemetryService::class.java)
+        private val knownStatuses = setOf("idle", "moving_to_pickup", "driving", "relocating")
+    }
+
+    private val meterRegistry = meterRegistry
+    private fun receivedCounter(status: String) = Counter.builder("baro_control_telemetry_received_total")
+        .description("Telemetry messages received")
+        .tag("status", status)
+        .register(this.meterRegistry)
+    private val kafkaPublishedCounter = Counter.builder("baro_control_telemetry_kafka_published_total")
+        .description("Telemetry messages published to Kafka")
+        .register(meterRegistry)
+    private val kafkaPublishFailedCounter = Counter.builder("baro_control_telemetry_kafka_publish_failed_total")
+        .description("Telemetry messages failed to publish to Kafka")
+        .register(meterRegistry)
+    private val invalidVehicleIdCounter = Counter.builder("baro_control_telemetry_invalid_vehicle_id_total")
+        .description("Telemetry messages with invalid vehicle id")
+        .register(meterRegistry)
 
     fun handleTelemetry(vehicleId: String, p: TelemetryPayload) {
-        stateStore.update(
-            VehicleState(
-                vehicleId  = vehicleId,
-                carNumber  = p.carNumber,
-                latitude   = p.latitude,
-                longitude  = p.longitude,
-                speed      = p.speed,
-                battery    = p.battery.toInt(),
-                heading    = p.heading,
-                status     = p.status,
-                timestamp  = p.timestamp,
-            )
+        val normalizedStatus = p.status.takeIf { it in knownStatuses } ?: "unknown"
+        receivedCounter(normalizedStatus).increment()
+
+        val state = VehicleState(
+            vehicleId = vehicleId,
+            carNumber = p.carNumber,
+            latitude = p.latitude,
+            longitude = p.longitude,
+            speed = p.speed,
+            battery = p.battery.toInt(),
+            heading = p.heading,
+            status = p.status,
+            timestamp = p.timestamp,
         )
 
         val carId = vehicleId.toLongOrNull() ?: run {
             log.warn("vehicleId '{}' 를 Long으로 변환할 수 없어 Kafka publish 생략", vehicleId)
+            invalidVehicleIdCounter.increment()
+            updateState(state)
             return
         }
 
@@ -46,8 +70,28 @@ class TelemetryService(
             "timestamp"  to p.timestamp,
             "car_number" to p.carNumber,
         )
-        kafkaTemplate.send(vehicleDataTopic, carId.toString(), message).whenComplete { _, ex ->
-            if (ex != null) log.error("Kafka publish 실패 [carId={}]: {}", carId, ex.message)
+        try {
+            kafkaTemplate.send(vehicleDataTopic, carId.toString(), message).whenComplete { _, ex ->
+                if (ex != null) {
+                    kafkaPublishFailedCounter.increment()
+                    log.error("Kafka publish 실패 [carId={}]: {}", carId, ex.message)
+                } else {
+                    kafkaPublishedCounter.increment()
+                }
+            }
+        } catch (exception: Exception) {
+            kafkaPublishFailedCounter.increment()
+            log.error("Kafka publish 실패 [carId={}]: {}", carId, exception.message)
+        }
+
+        updateState(state)
+    }
+
+    private fun updateState(state: VehicleState) {
+        try {
+            stateStore.update(state)
+        } catch (exception: Exception) {
+            log.error("Vehicle state update 실패 [vehicleId={}]: {}", state.vehicleId, exception.message)
         }
     }
 }

--- a/control-service/src/main/kotlin/com/baro/control/service/VehicleStateStore.kt
+++ b/control-service/src/main/kotlin/com/baro/control/service/VehicleStateStore.kt
@@ -1,6 +1,8 @@
 package com.baro.control.service
 
 import com.baro.control.dto.VehicleState
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -8,11 +10,16 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
 @Component
-class VehicleStateStore {
+class VehicleStateStore(
+    meterRegistry: MeterRegistry,
+) {
     private val states = ConcurrentHashMap<String, VehicleState>()
     private val emitters = CopyOnWriteArrayList<SseEmitter>()
     private val relocationRoutes = ConcurrentHashMap<String, List<Map<String, Double>>>()
     private val relocationTargets = ConcurrentHashMap<String, Map<String, Double>>()
+    private val broadcastFailureCounter = Counter.builder("baro_control_sse_send_failures_total").tag("phase", "broadcast").register(meterRegistry)
+    private val heartbeatFailureCounter = Counter.builder("baro_control_sse_send_failures_total").tag("phase", "heartbeat").register(meterRegistry)
+    private val initialFailureCounter = Counter.builder("baro_control_sse_send_failures_total").tag("phase", "initial").register(meterRegistry)
 
     fun setRelocation(vehicleId: String, route: List<Map<String, Double>>, target: Map<String, Double>) {
         relocationRoutes[vehicleId] = route
@@ -53,6 +60,7 @@ class VehicleStateStore {
                     emitter.send(SseEmitter.event().name("vehicle").data(state))
                 }
             } catch (e: Exception) {
+                initialFailureCounter.increment()
                 emitters.remove(emitter)
                 emitter.completeWithError(e)
                 return emitter
@@ -71,6 +79,7 @@ class VehicleStateStore {
                     emitter.send(SseEmitter.event().name("ping").data(""))
                 }
             } catch (e: Exception) {
+                heartbeatFailureCounter.increment()
                 emitter.completeWithError(e)
                 dead.add(emitter)
             }
@@ -86,6 +95,7 @@ class VehicleStateStore {
                     emitter.send(SseEmitter.event().name("vehicle").data(state))
                 }
             } catch (e: Exception) {
+                broadcastFailureCounter.increment()
                 emitter.completeWithError(e)
                 dead.add(emitter)
             }

--- a/control-service/src/main/resources/application.yml
+++ b/control-service/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: ${CONTROL_MANAGEMENT_ENDPOINTS:health,info,metrics,prometheus}
 
 mqtt:
   mode: ${MQTT_MODE:local}

--- a/dispatch-service/build.gradle.kts
+++ b/dispatch-service/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(project(":common-kakao"))
     implementation(project(":common-web"))
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CarStateService.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/application/service/CarStateService.kt
@@ -2,32 +2,69 @@ package com.baro.dispatch.application.service
 
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
 import com.baro.dispatch.infrastructure.kafka.CarStatus
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 @Service
 open class CarStateService(
     private val dispatchableCarProjection: DispatchableCarProjection,
     private val vehicleLocationStreamService: VehicleLocationStreamService,
+    private val meterRegistry: MeterRegistry,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
+    private fun stateEventCounter(status: String) = Counter.builder("baro_dispatch_vehicle_state_events_total")
+        .tag("status", status)
+        .register(meterRegistry)
+    private val idleGeoSavesCounter = Counter.builder("baro_dispatch_idle_geo_saves_total").register(meterRegistry)
+    private val idleGeoRemovesCounter = Counter.builder("baro_dispatch_idle_geo_removes_total").register(meterRegistry)
+    private val currentStatusCounts = ConcurrentHashMap<String, AtomicInteger>()
+    private val carStatuses = ConcurrentHashMap<Long, String>()
+
+    init {
+        CarStatus.entries.forEach { status ->
+            Gauge.builder("baro_dispatch_vehicle_status_current", currentStatusCounts.computeIfAbsent(status.value) { AtomicInteger(0) }) { it.get().toDouble() }
+                .tag("status", status.value)
+                .register(meterRegistry)
+        }
+    }
 
     open fun handle(command: CarStateCommand) {
         log.debug("차량 상태 데이터를 수신했습니다. carId={}, status={}, timestamp={}", command.carId, command.status.value, command.timestamp)
+        stateEventCounter(command.status.value).increment()
+        updateStatusCounts(command.carId, command.status.value)
         when (command.status) {
             CarStatus.IDLE, CarStatus.RELOCATING -> {
                 log.debug("배차 가능한 차량 위치를 Redis GEO에 저장합니다. carId={}, latitude={}, longitude={}", command.carId, command.latitude, command.longitude)
                 dispatchableCarProjection.saveIdleCarLocation(command.carId, command.carNumber, command.latitude, command.longitude)
+                idleGeoSavesCounter.increment()
             }
 
             CarStatus.MOVING_TO_PICKUP, CarStatus.DRIVING -> {
                 log.debug("배차 가능 차량 목록에서 제외합니다. carId={}, status={}", command.carId, command.status.value)
                 dispatchableCarProjection.removeCar(command.carId)
+                idleGeoRemovesCounter.increment()
             }
         }
 
         vehicleLocationStreamService.publish(command)
+    }
+
+    private fun updateStatusCounts(carId: Long, newStatus: String) {
+        val previousStatus = carStatuses.put(carId, newStatus)
+        if (previousStatus == newStatus) return
+        if (previousStatus != null && previousStatus != newStatus) {
+            currentStatusCounts.computeIfPresent(previousStatus) { _, counter ->
+                counter.updateAndGet { value -> if (value > 0) value - 1 else 0 }
+                counter
+            }
+        }
+        currentStatusCounts.computeIfAbsent(newStatus) { AtomicInteger(0) }.incrementAndGet()
     }
 }
 

--- a/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
+++ b/dispatch-service/src/main/kotlin/com/baro/dispatch/infrastructure/redis/RedisDispatchableCarProjection.kt
@@ -2,6 +2,9 @@ package com.baro.dispatch.infrastructure.redis
 
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
 import com.baro.dispatch.application.port.out.DispatchableCarCandidate
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.data.geo.Distance
 import org.springframework.data.geo.Metrics
 import org.slf4j.LoggerFactory
@@ -19,9 +22,18 @@ private fun carNumberKey(carId: Long) = "dispatch:car:$carId:number"
 class RedisDispatchableCarProjection(
     private val redisTemplate: RedisTemplate<String, String>,
     private val properties: DispatchRedisProperties,
+    meterRegistry: MeterRegistry,
 ) : DispatchableCarProjection {
 
     private val log = LoggerFactory.getLogger(javaClass)
+    private val candidateSearchCounter = Counter.builder("baro_dispatch_idle_geo_candidate_search_total").register(meterRegistry)
+    private val candidateNotFoundCounter = Counter.builder("baro_dispatch_idle_geo_candidate_not_found_total").register(meterRegistry)
+    private val staleCleanupCounter = Counter.builder("baro_dispatch_idle_geo_stale_cleanup_total").register(meterRegistry)
+
+    init {
+        Gauge.builder("baro_dispatch_idle_geo_count") { readIdleGeoCount() }
+            .register(meterRegistry)
+    }
 
     override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) {
         log.info("Redis GEO에 배차 가능 차량을 저장합니다. carId={}, key={}", carId, properties.idleCarGeoKey)
@@ -54,6 +66,7 @@ class RedisDispatchableCarProjection(
 
         if (candidates.isEmpty()) {
             log.warn("반경 {}km 내 유효한(non-stale) 배차 가능 차량이 없습니다.", maxRadiusKm)
+            candidateNotFoundCounter.increment()
         }
         return candidates
     }
@@ -69,6 +82,8 @@ class RedisDispatchableCarProjection(
                 .sortAscending()
                 .limit(properties.idleCarMaxCandidates.toLong()),
         ) ?: return emptyList()
+
+        candidateSearchCounter.increment()
 
         val thresholdMs = properties.stalenessThresholdSeconds * 1_000L
         val now = System.currentTimeMillis()
@@ -125,6 +140,7 @@ class RedisDispatchableCarProjection(
 
         try {
             log.info("stale 배차 가능 차량을 Redis GEO에서 정리합니다. carIds={}", carIds)
+            staleCleanupCounter.increment()
             removeCarsFromProjection(carIds)
         } catch (exception: Exception) {
             log.error("stale 차량 정리 중 오류가 발생했습니다. carIds={}", carIds, exception)
@@ -139,5 +155,11 @@ class RedisDispatchableCarProjection(
             *carIds.map { it.toString() }.toTypedArray(),
         )
         redisTemplate.delete(carIds.flatMap { listOf(carMetaKey(it), carNumberKey(it)) })
+    }
+
+    private fun readIdleGeoCount(): Double = try {
+        (redisTemplate.execute { connection -> connection.zCard(properties.idleCarGeoKey.toByteArray()) } ?: 0L).toDouble()
+    } catch (_: Exception) {
+        Double.NaN
     }
 }

--- a/dispatch-service/src/main/resources/application.yml
+++ b/dispatch-service/src/main/resources/application.yml
@@ -32,7 +32,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: ${DISPATCH_MANAGEMENT_ENDPOINTS:health,info,metrics,prometheus}
 
 springdoc:
   api-docs:

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/application/service/CarStateServiceTest.kt
@@ -3,6 +3,7 @@ package com.baro.dispatch.application.service
 import com.baro.dispatch.application.port.out.DispatchableCarProjection
 import com.baro.dispatch.application.port.out.DispatchableCarCandidate
 import com.baro.dispatch.infrastructure.kafka.CarStatus
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -21,7 +22,7 @@ class CarStateServiceTest {
             }
 
             override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
-        }, noopVehicleLocationStreamService())
+        }, noopVehicleLocationStreamService(), SimpleMeterRegistry())
 
         service.handle(
             CarStateCommand(
@@ -54,7 +55,7 @@ class CarStateServiceTest {
             }
 
             override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
-        }, noopVehicleLocationStreamService())
+        }, noopVehicleLocationStreamService(), SimpleMeterRegistry())
 
         service.handle(
             CarStateCommand(
@@ -87,7 +88,7 @@ class CarStateServiceTest {
             }
 
             override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
-        }, noopVehicleLocationStreamService())
+        }, noopVehicleLocationStreamService(), SimpleMeterRegistry())
 
         service.handle(
             CarStateCommand(

--- a/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
+++ b/dispatch-service/src/test/kotlin/com/baro/dispatch/infrastructure/kafka/CarStateConsumerTest.kt
@@ -5,6 +5,7 @@ import com.baro.dispatch.application.port.out.DispatchableCarCandidate
 import com.baro.dispatch.application.service.CarStateCommand
 import com.baro.dispatch.application.service.CarStateService
 import com.baro.dispatch.application.service.VehicleLocationStreamService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -18,7 +19,7 @@ class CarStateConsumerTest {
                 override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) = Unit
                 override fun removeCar(carId: Long) = Unit
                 override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
-            }, noopVehicleLocationStreamService()) {
+            }, noopVehicleLocationStreamService(), SimpleMeterRegistry()) {
                 override fun handle(command: CarStateCommand) {
                     received = command
                 }
@@ -65,7 +66,7 @@ class CarStateConsumerTest {
                 override fun saveIdleCarLocation(carId: Long, carNumber: String?, latitude: Double, longitude: Double) = Unit
                 override fun removeCar(carId: Long) = Unit
                 override fun findNearestIdleCars(latitude: Double, longitude: Double): List<DispatchableCarCandidate> = emptyList()
-            }, noopVehicleLocationStreamService()) {
+            }, noopVehicleLocationStreamService(), SimpleMeterRegistry()) {
                 override fun handle(command: CarStateCommand) {
                     received = command
                 }


### PR DESCRIPTION
## 요약
- control-service telemetry/Kafka/SSE 메트릭 추가
- dispatch-service 차량 상태/Redis GEO/후보 탐색 도메인 메트릭 추가
- Prometheus actuator endpoint 노출 설정 추가

## 검증
- ./gradlew :control-service:test :dispatch-service:test